### PR TITLE
EVALSYS-1437 Create View Only admin user

### DIFF
--- a/api/src/java/org/sakaiproject/evaluation/constant/EvalConstants.java
+++ b/api/src/java/org/sakaiproject/evaluation/constant/EvalConstants.java
@@ -262,6 +262,13 @@ public class EvalConstants {
      * Permission: User can take an evaluation for any group they have this permission in
      */
     public final static String PERM_TAKE_EVALUATION = "eval.take.evaluation";
+    
+    /**
+     * Permission: admin read only. Assign just theis role to a user to grant them admin access to view evaluation and evaluation reports but not modify anything
+     */
+    public final static String PERM_ADMIN_READONLY = "eval.admin.readonly";
+    
+    
     /**
      * SPECIAL CASE
      * Permission: User is marked as an assistant in a section/course/group,

--- a/api/src/java/org/sakaiproject/evaluation/logic/EvalCommonLogic.java
+++ b/api/src/java/org/sakaiproject/evaluation/logic/EvalCommonLogic.java
@@ -257,4 +257,11 @@ public interface EvalCommonLogic extends ExternalUsers, ExternalEvalGroups, Exte
      */
     public void registerEvalGroupsProvider(EvalGroupsProvider provider);
 
+    /**
+     * Check if this user has readonly admin access in the evaluation system
+     * 
+     * @param userId the internal user id (not username)
+     * @return true if the user has readonly admin access, false otherwise
+     */
+    public boolean isUserReadonlyAdmin(String userId);
 }

--- a/api/src/java/org/sakaiproject/evaluation/logic/externals/ExternalSecurity.java
+++ b/api/src/java/org/sakaiproject/evaluation/logic/externals/ExternalSecurity.java
@@ -41,5 +41,12 @@ public interface ExternalSecurity {
     * @return true if allowed, false otherwise
     */
    public boolean isUserAllowedInEvalGroup(String userId, String permission, String evalGroupId);
+   
+   /**
+    * Check if this user has the readonly admin permission
+    * @param userId the internal user id (not username)
+    * @return true if the user has readonly admin access, false otherwise
+    */
+   public boolean isUserReadonlyAdmin(String userId);
 
 }

--- a/api/src/java/org/sakaiproject/evaluation/providers/EvalGroupsProvider.java
+++ b/api/src/java/org/sakaiproject/evaluation/providers/EvalGroupsProvider.java
@@ -34,10 +34,11 @@ import org.sakaiproject.evaluation.logic.model.EvalGroup;
  * </bean>
  * </xmp>
  * <br/>
- * The 3 permissions this provider has to deal with 
+ * The 4 permissions this provider has to deal with 
  * are {@link #PERM_BE_EVALUATED} (roughly equivalent to instructor role) 
  * and {@link #PERM_TAKE_EVALUATION} (roughly equivalent to student role) 
- * and {@link #PERM_TA_ROLE} (roughly equivalent to teaching assistants role), 
+ * and {@link #PERM_TA_ROLE} (roughly equivalent to teaching assistants role)
+ * and {@link #PERM_ADMIN_READONLY} (an admin read only role) 
  * compare the incoming permission to the constant
  * and only handle the cases indicated (do not try to handle all possible permissions)<br/>
  * <b>Note</b>: Specifically this allows us to reference eval groups and enrollments which
@@ -64,7 +65,10 @@ public interface EvalGroupsProvider {
      * it means they can see the groups in the listing when assigning the eval to users via groups
      */
     public final static String PERM_ASSIGN_EVALUATION = "provider.assign.eval";
-	/**
+	
+    public final static String PERM_ADMIN_READONLY = "provider.admin.readonly";
+    
+    /**
 	 * Permission: User is marked as a TA in a section/course and will be treated as such,
 	 * this is a special case permission
 	 * http://bugs.sakaiproject.org/jira/browse/EVALSYS-345

--- a/impl/src/java/org/sakaiproject/evaluation/logic/EvalCommonLogicImpl.java
+++ b/impl/src/java/org/sakaiproject/evaluation/logic/EvalCommonLogicImpl.java
@@ -29,7 +29,6 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.sakaiproject.evaluation.constant.EvalConstants;
 import org.sakaiproject.evaluation.dao.EvalAdhocSupport;
 import org.sakaiproject.evaluation.dao.EvalAdminSupport;
@@ -881,5 +880,19 @@ public class EvalCommonLogicImpl implements EvalCommonLogic {
             this.evalGroupsProvider = null;
         }
     }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.sakaiproject.evaluation.logic.externals.ExternalSecurity#isUserReadonlyAdmin(java.lang.String)
+     */
+	public boolean isUserReadonlyAdmin(String userId) {
+		//unlock check will always return true for sakai admins.
+		//sakai admins cant be readonly admins though as readonly is a lower privilege, so override this
+		if(this.isUserSakaiAdmin(userId)){
+			return false;
+		}
+		
+		return externalLogic.isUserReadonlyAdmin(userId);
+	}
 
 }

--- a/impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImpl.java
+++ b/impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImpl.java
@@ -653,9 +653,9 @@ public class EvalEvaluationSetupServiceImpl implements EvalEvaluationSetupServic
         }
 
         String[] evalGroupIds = null;
-        if (commonLogic.isUserAdmin(userId)) {
+        if (commonLogic.isUserAdmin(userId) || commonLogic.isUserReadonlyAdmin(userId)) {
             // null out the userId so we get all evaluations
-            userId = null;
+            userId = null;            
         } else {
             if (showNotOwned) {
                 // get the list of all assignments where this user is instructor

--- a/impl/src/java/org/sakaiproject/evaluation/logic/ReportingPermissionsImpl.java
+++ b/impl/src/java/org/sakaiproject/evaluation/logic/ReportingPermissionsImpl.java
@@ -100,7 +100,7 @@ public class ReportingPermissionsImpl implements ReportingPermissions {
 
         boolean canViewResponses = false; // is user able to view any results/responses at all
         boolean checkBasedOnRole = false; // get the groups based on the current user role
-
+        
         // 1) Is this user an admin or evaluation owner
         // 2) Is this user the evaluation owner?
         if (evalBeanUtils.checkUserPermission(currentUserId, evaluation.getOwner())) {
@@ -119,6 +119,11 @@ public class ReportingPermissionsImpl implements ReportingPermissions {
         }
         else if (EvalConstants.SHARING_PRIVATE.equals(evaluation.getResultsSharing())) {
             canViewResponses = false;
+        }
+        else if (commonLogic.isUserReadonlyAdmin(currentUserId)) {
+        	//same settings for admin
+        	canViewResponses = true;
+        	checkBasedOnRole = false;
         }
         else {
             canViewResponses = true;
@@ -185,6 +190,10 @@ public class ReportingPermissionsImpl implements ReportingPermissions {
         // 4/5 (combined check)
         else if ( checkGroupsForEvalUserGroups(evaluation, groupIds, currentUserId) ) {
             canViewResponses = true;
+        }
+        else if (commonLogic.isUserReadonlyAdmin(currentUserId)) {
+        	//same settings for admin
+        	canViewResponses = true;
         }
         else {
             canViewResponses = false;

--- a/impl/src/java/org/sakaiproject/evaluation/logic/externals/EvalExternalLogicImpl.java
+++ b/impl/src/java/org/sakaiproject/evaluation/logic/externals/EvalExternalLogicImpl.java
@@ -960,6 +960,7 @@ public class EvalExternalLogicImpl implements EvalExternalLogic {
         functionManager.registerFunction(EvalConstants.PERM_ASSIGN_EVALUATION);
         functionManager.registerFunction(EvalConstants.PERM_BE_EVALUATED);
         functionManager.registerFunction(EvalConstants.PERM_TAKE_EVALUATION);
+        functionManager.registerFunction(EvalConstants.PERM_ADMIN_READONLY);
     }
 
     /**
@@ -990,6 +991,8 @@ public class EvalExternalLogicImpl implements EvalExternalLogic {
             return EvalGroupsProvider.PERM_BE_EVALUATED;
         } else if (EvalConstants.PERM_ASSIGN_EVALUATION.equals(permission)) {
             return EvalGroupsProvider.PERM_ASSIGN_EVALUATION;
+        } else if (EvalConstants.PERM_ADMIN_READONLY.equals(permission)) {
+            return EvalGroupsProvider.PERM_ADMIN_READONLY;
         } else if (EvalConstants.PERM_ASSISTANT_ROLE.equals(permission)) {
             return EvalGroupsProvider.PERM_TA_ROLE;
         }
@@ -1356,6 +1359,17 @@ public class EvalExternalLogicImpl implements EvalExternalLogic {
         if (session !=null) {
             session.setMaxInactiveInterval(seconds);
         }
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.sakaiproject.evaluation.logic.externals.ExternalSecurity#isUserReadonlyAdmin(java.lang.String)
+     */
+    public boolean isUserReadonlyAdmin(String userId) {
+    	if (securityService.unlock(userId, EvalConstants.PERM_ADMIN_READONLY, this.getCurrentEvalGroup())) {
+            return true;
+        }
+    	return false;
     }
 
 }

--- a/impl/src/test/org/sakaiproject/evaluation/test/mocks/MockEvalExternalLogic.java
+++ b/impl/src/test/org/sakaiproject/evaluation/test/mocks/MockEvalExternalLogic.java
@@ -657,4 +657,10 @@ public class MockEvalExternalLogic implements EvalExternalLogic {
         // TODO Auto-generated method stub
     }
 
+	@Override
+	public boolean isUserReadonlyAdmin(String userId) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
 }

--- a/tool/src/java/org/sakaiproject/evaluation/tool/bundle/permissions.properties
+++ b/tool/src/java/org/sakaiproject/evaluation/tool/bundle/permissions.properties
@@ -2,4 +2,4 @@ desc-eval.assign.evaluation=May assign evaluations
 desc-eval.be.evaluated=May be evaluated
 desc-eval.take.evaluation=May take evaluations
 desc-eval.write.template=May create evaluation templates
-desc-eval.admin.readonly=Grant user administrative readonly access. Can view evaluations and evaluation reports.
+desc-eval.admin.readonly=Grant user administrative readonly access. Can view all evaluations and reports.

--- a/tool/src/java/org/sakaiproject/evaluation/tool/bundle/permissions.properties
+++ b/tool/src/java/org/sakaiproject/evaluation/tool/bundle/permissions.properties
@@ -2,3 +2,4 @@ desc-eval.assign.evaluation=May assign evaluations
 desc-eval.be.evaluated=May be evaluated
 desc-eval.take.evaluation=May take evaluations
 desc-eval.write.template=May create evaluation templates
+desc-eval.admin.readonly=Grant user administrative readonly access. Can view evaluations and evaluation reports.


### PR DESCRIPTION
Create a permission that can be assigned to a user to grant them readonly admin access. Users with this permission can see all evaluations and reports but not modify anything.