### PR TITLE
EVALSYS-1439 standardize the markup of the navIntraTool toolbar in evals

### DIFF
--- a/tool/src/webapp/component-templates/nav_bar.html
+++ b/tool/src/webapp/component-templates/nav_bar.html
@@ -22,10 +22,10 @@
 
 <body>
 <!-- everything outside this div is thrown away -->
-<div rsf:id="evals-navigation:" class="navIntraTool">
-   <div rsf:id="navigation-cell:" style="display:inline">
-      <a rsf:id="item-link" href="list.html">evals</a>
-  </div>
-</div>
+<ul rsf:id="evals-navigation:" class="navIntraTool">
+    <li rsf:id="navigation-cell:">
+        <span><a rsf:id="item-link" href="list.html">evals</a></span>
+    </li>
+</ul>
 </body>
 </html>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/EVALSYS-1439

Evals doesn't conform to the standard for the navIntraTool tool bar. It uses divs instead of:

.navIntraTool > li > span > a 