### PR TITLE
EVALSYS-585 - Add standalone tab to manage ad-hoc groups

### DIFF
--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages.properties
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages.properties
@@ -18,6 +18,7 @@ general.public=Public
 general.private=Private
 general.command.edit=Edit
 general.command.delete=Remove
+general.command.cancel=Cancel
 general.command.chown=Change Owner
 general.command.split.block=Separate this group into individual items
 general.command.preview=Preview
@@ -1269,10 +1270,26 @@ modifyadhocgroup.message.badusers.noadhocusers=Could not add users {0}. Entries 
 user accounts.
 modifyadhocgroup.message.existingusers={0} already in adhoc group.
 modifyadhocgroup.message.notitle=The title for this adhoc group cannot be blank
+modifyadhocgroup.message.duplicatetitle=An adhoc group with this name already exists.
 modifyadhocgroup.message.emptygroup=There are currently no users in this adhoc group.
 modifyadhocgroup.message.instructions=Please enter a group name and list of participants.
 modifyadhocgroup.message.members=Please enter the usernames or email addresses of the people you want to survey in the box below, (one per line).
 modifyadhocgroup.group.deleted = Deleted adhoc group
+
+# Page for listing and managing Adhoc Groups
+controladhocgroups.page.title=My Adhoc Groups
+controladhocgroups.page.instruction=Manage your adhoc groups. Groups used in active or closed evaluations cannot be modified here; to change the membership of such a group, edit the evaluation directly.
+controladhocgroups.add.new.group.link=Create a new Adhoc Group
+controladhocgroups.no.groups=You have no adhoc groups yet.
+controladhocgroups.table.header.title=Group Name
+controladhocgroups.table.header.members=Members
+controladhocgroups.table.header.evaluations=Evaluations
+controladhocgroups.group.not.used=Not used in any evaluation
+controladhocgroups.group.locked.tooltip=This group is used in an active or closed evaluation and cannot be modified here.
+controladhocgroups.delete.confirm=Are you sure you want to delete this adhoc group?
+controladhocgroups.deleted=Adhoc group deleted successfully.
+controladhocgroups.group.saved=Adhoc group “{0}” saved.
+controladhocgroups.cannot.delete.locked=This group cannot be deleted because it is used in an active or closed evaluation.
 
 # Page for evaluation notifications
 evalnotify.page.title=Send Evaluation Notifications

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages_es_ES.properties
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages_es_ES.properties
@@ -18,6 +18,7 @@ general.public=P\u00FAblico
 general.private=Privado
 general.command.edit=Editar
 general.command.delete=Eliminar
+general.command.cancel=Cancelar
 general.command.chown=Cambiar Propietario
 general.command.split.block=Separar este grupo en elementos individuales
 general.command.preview=Previsualizar
@@ -847,8 +848,24 @@ modifyadhocgroup.message.badusers.noadhocusers=No se pudo agregar usuarios {0}. 
 usuario v\u00E1lidas.
 
 modifyadhocgroup.message.existingusers={0} ya existe en el grupo adhoc.
+modifyadhocgroup.message.duplicatetitle=Ya existe un grupo ad-hoc con ese nombre.
 modifyadhocgroup.message.emptygroup=No hay usuarios actualmente en este grupo.
 modifyadhocgroup.message.instructions=Introduzca un nombre de grupo y una lista de participantes. Los participantes deben ser listados uno por linea mediante IDs o direcciones de emails validos.
 modifyadhocgroup.message.pastetype=Pegue o escriba los correos electr\u00F3nicos de las personas que tienen que ser encuestadas a continuaci\u00F3n. Un nombre de usuario o correo electr\u00F3nico por l\u00EDnea.
 
-permission.message=Establecer los permisos de Evaluaciones para el sitio 
+# P\u00E1gina de listado y gesti\u00F3n de Grupos Adhoc
+controladhocgroups.page.title=Mis Grupos Ad-hoc
+controladhocgroups.page.instruction=Gestione sus grupos ad-hoc. Los grupos utilizados en encuestas activas o cerradas no pueden modificarse aqu\u00ED; para cambiar los miembros de ese grupo, edite la encuesta directamente.
+controladhocgroups.add.new.group.link=Crear un nuevo Grupo Ad-hoc
+controladhocgroups.no.groups=Todav\u00EDa no tiene ning\u00FAn grupo ad-hoc.
+controladhocgroups.table.header.title=Nombre del grupo
+controladhocgroups.table.header.members=Miembros
+controladhocgroups.table.header.evaluations=Encuestas
+controladhocgroups.group.not.used=No usado en ninguna encuesta
+controladhocgroups.group.locked.tooltip=Este grupo se usa en una encuesta activa o cerrada y no puede modificarse aqu\u00ED.
+controladhocgroups.delete.confirm=\u00BFEst\u00E1 seguro de que desea eliminar este grupo ad-hoc?
+controladhocgroups.deleted=Grupo ad-hoc eliminado correctamente.
+controladhocgroups.group.saved=Grupo ad-hoc "{0}" guardado.
+controladhocgroups.cannot.delete.locked=Este grupo no puede eliminarse porque est\u00E1 en uso en una encuesta activa o cerrada.
+
+permission.message=Establecer los permisos de Evaluaciones para el sitio

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ControlAdhocGroupsController.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ControlAdhocGroupsController.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2005 Sakai Foundation Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.sakaiproject.evaluation.tool.controllers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.sakaiproject.evaluation.constant.EvalConstants;
+import org.sakaiproject.evaluation.logic.EvalSettings;
+import org.sakaiproject.evaluation.model.EvalAdhocGroup;
+import org.sakaiproject.evaluation.model.EvalEvaluation;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequestMapping("/control_adhoc_groups")
+public class ControlAdhocGroupsController extends EvalControllerSupport {
+
+    @Data
+    public static class EvalInfo {
+        private final Long evalId;
+        private final String title;
+        private final String stateKey;
+        private final boolean locked;
+    }
+
+    @Data
+    public static class GroupRow {
+        private final Long groupId;
+        private final String title;
+        private final int memberCount;
+        private final List<EvalInfo> evaluations;
+        private final boolean canEdit;
+        private final boolean canDelete;
+    }
+
+    @GetMapping
+    public String show(Model model) {
+        String userId = commonLogic.getCurrentUserId();
+        if (commonLogic.isUserAnonymous(userId))
+            throw new SecurityException("Anonymous users cannot access adhoc groups");
+
+        if (!Boolean.TRUE.equals(settings.get(EvalSettings.ENABLE_ADHOC_GROUPS)))
+            return "redirect:/summary";
+
+        List<EvalAdhocGroup> groups = commonLogic.getAdhocGroupsForOwner(userId);
+        List<GroupRow> rows = new ArrayList<>();
+
+        for (EvalAdhocGroup group : groups) {
+            List<EvalEvaluation> evals = evaluationService.getEvaluationsForEvalGroups(
+                    new String[]{group.getEvalGroupId()}, 0, 0);
+
+            boolean anyLocked = false;
+            List<EvalInfo> evalInfos = new ArrayList<>();
+            for (EvalEvaluation eval : evals) {
+                String state = evaluationService.updateEvaluationState(eval.getId());
+                boolean locked = isLockedState(state);
+                if (locked) anyLocked = true;
+                evalInfos.add(new EvalInfo(eval.getId(), eval.getTitle(),
+                        "state.label." + state.toLowerCase(), locked));
+            }
+
+            int memberCount = group.getParticipantIds() != null ? group.getParticipantIds().size() : 0;
+            rows.add(new GroupRow(group.getId(), group.getTitle(), memberCount, evalInfos,
+                    !anyLocked, evals.isEmpty()));
+        }
+
+        model.addAttribute("groupRows", rows);
+        return "control_adhoc_groups";
+    }
+
+    @PostMapping("/delete")
+    public String delete(@RequestParam Long adhocGroupId, RedirectAttributes ra) {
+        String userId = commonLogic.getCurrentUserId();
+
+        EvalAdhocGroup group = commonLogic.getAdhocGroupById(adhocGroupId);
+        if (group == null)
+            throw new IllegalArgumentException("Adhoc group not found: " + adhocGroupId);
+        if (!userId.equals(group.getOwner()))
+            throw new SecurityException("Only the owner can delete an adhoc group: " + userId);
+
+        List<EvalEvaluation> evals = evaluationService.getEvaluationsForEvalGroups(
+                new String[]{group.getEvalGroupId()}, 0, 0);
+        for (EvalEvaluation eval : evals) {
+            if (isLockedState(evaluationService.updateEvaluationState(eval.getId()))) {
+                ra.addFlashAttribute("errorMessage", "controladhocgroups.cannot.delete.locked");
+                return "redirect:/control_adhoc_groups";
+            }
+        }
+
+        commonLogic.deleteAdhocGroup(adhocGroupId);
+        log.info("User ({}) deleted adhoc group ({})", userId, adhocGroupId);
+        ra.addFlashAttribute("successMessage", "controladhocgroups.deleted");
+        return "redirect:/control_adhoc_groups";
+    }
+
+    static boolean isLockedState(String state) {
+        return EvalConstants.EVALUATION_STATE_ACTIVE.equals(state)
+                || EvalConstants.EVALUATION_STATE_GRACEPERIOD.equals(state)
+                || EvalConstants.EVALUATION_STATE_CLOSED.equals(state)
+                || EvalConstants.EVALUATION_STATE_VIEWABLE.equals(state);
+    }
+}

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ModifyAdhocGroupController.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ModifyAdhocGroupController.java
@@ -25,10 +25,12 @@ import javax.annotation.Resource;
 
 import org.sakaiproject.evaluation.constant.EvalConstants;
 import org.sakaiproject.evaluation.logic.EvalCommonLogic;
+import org.sakaiproject.evaluation.logic.EvalEvaluationService;
 import org.sakaiproject.evaluation.logic.EvalSettings;
 import org.sakaiproject.evaluation.logic.model.EvalUser;
 import org.sakaiproject.evaluation.model.EvalAdhocGroup;
 import org.sakaiproject.evaluation.model.EvalAdhocUser;
+import org.sakaiproject.evaluation.model.EvalEvaluation;
 import org.sakaiproject.evaluation.utils.EvalUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -49,6 +51,9 @@ public class ModifyAdhocGroupController {
     @Resource(name = "org.sakaiproject.evaluation.logic.EvalCommonLogic")
     private EvalCommonLogic commonLogic;
 
+    @Resource(name = "org.sakaiproject.evaluation.logic.EvalEvaluationService")
+    private EvalEvaluationService evaluationService;
+
     @Resource(name = "org.sakaiproject.evaluation.logic.EvalSettings")
     private EvalSettings settings;
 
@@ -68,17 +73,25 @@ public class ModifyAdhocGroupController {
         if (commonLogic.isUserAnonymous(currentUserId))
             throw new SecurityException("Anonymous users cannot access adhoc groups");
 
+        // Flash attributes set by POST on validation error to pre-fill the form
+        String prefillTitle   = (String) model.asMap().get("prefillTitle");
+        String prefillMembers = (String) model.asMap().getOrDefault("prefillMembers", "");
+
         model.addAttribute("adhocGroupId", adhocGroupId);
         model.addAttribute("returnUrl", returnUrl);
         model.addAttribute("isNew", adhocGroupId == null);
-        model.addAttribute("groupTitle", "");
+        model.addAttribute("prefillMembers", prefillMembers);
 
         if (adhocGroupId != null) {
             EvalAdhocGroup group = commonLogic.getAdhocGroupById(adhocGroupId);
             if (group == null) throw new IllegalArgumentException("Adhoc group not found: " + adhocGroupId);
             if (!currentUserId.equals(group.getOwner()))
                 throw new SecurityException("Only owners can modify adhocgroups: " + currentUserId);
-            model.addAttribute("groupTitle", group.getTitle());
+            if (isGroupLocked(group)) {
+                model.addAttribute("errorMessage", "controladhocgroups.group.locked.tooltip");
+                model.addAttribute("readOnly", true);
+            }
+            model.addAttribute("groupTitle", prefillTitle != null ? prefillTitle : group.getTitle());
 
             List<String> participantIds = group.getParticipantIds();
             List<MemberRow> members = new ArrayList<>();
@@ -92,6 +105,8 @@ public class ModifyAdhocGroupController {
                 }
             }
             model.addAttribute("members", members);
+        } else {
+            model.addAttribute("groupTitle", prefillTitle != null ? prefillTitle : "");
         }
         return "modify_adhoc_group";
     }
@@ -108,7 +123,19 @@ public class ModifyAdhocGroupController {
 
         if (groupTitle.trim().isEmpty()) {
             ra.addFlashAttribute("errorMessage", "modifyadhocgroup.message.notitle");
+            ra.addFlashAttribute("prefillMembers", newMembers);
             return redirectToForm(adhocGroupId, returnUrl);
+        }
+
+        // Duplicate title check (case-insensitive, excluding the group being edited)
+        for (EvalAdhocGroup existing : commonLogic.getAdhocGroupsForOwner(currentUserId)) {
+            if (existing.getTitle().equalsIgnoreCase(groupTitle.trim())
+                    && !existing.getId().equals(adhocGroupId)) {
+                ra.addFlashAttribute("errorMessage", "modifyadhocgroup.message.duplicatetitle");
+                ra.addFlashAttribute("prefillTitle", groupTitle);
+                ra.addFlashAttribute("prefillMembers", newMembers);
+                return redirectToForm(adhocGroupId, returnUrl);
+            }
         }
 
         EvalAdhocGroup group;
@@ -118,13 +145,28 @@ public class ModifyAdhocGroupController {
             group = commonLogic.getAdhocGroupById(adhocGroupId);
             if (!currentUserId.equals(group.getOwner()))
                 throw new SecurityException("Only owners can modify adhocgroups: " + currentUserId);
+            if (isGroupLocked(group)) {
+                ra.addFlashAttribute("errorMessage", "controladhocgroups.group.locked.tooltip");
+                return redirectToForm(adhocGroupId, returnUrl);
+            }
             group.setTitle(groupTitle.trim());
         }
 
-        // Process the list of new members
+        // Process members — must happen before save so we can abort on invalid users
         List<String> rejected = new ArrayList<>();
         List<String> alreadyIn = new ArrayList<>();
         List<String> toAdd = addMembersFromText(newMembers, group, rejected, alreadyIn);
+
+        // Reject if any invalid users; return to form without saving
+        if (!rejected.isEmpty()) {
+            boolean useAdhocUsers = Boolean.TRUE.equals(settings.get(EvalSettings.ENABLE_ADHOC_USERS));
+            ra.addFlashAttribute("errorMessage",
+                    useAdhocUsers ? "modifyadhocgroup.message.badusers" : "modifyadhocgroup.message.badusers.noadhocusers");
+            ra.addFlashAttribute("errorArgs", new Object[]{ String.join(", ", rejected) });
+            ra.addFlashAttribute("prefillTitle", groupTitle);
+            ra.addFlashAttribute("prefillMembers", newMembers);
+            return redirectToForm(adhocGroupId, returnUrl);
+        }
 
         Set<String> all = new HashSet<>();
         if (group.getParticipantIds() != null) all.addAll(group.getParticipantIds());
@@ -134,23 +176,20 @@ public class ModifyAdhocGroupController {
         commonLogic.saveAdhocGroup(group);
         Long savedId = group.getId();
 
-        ra.addFlashAttribute("successMessage", "modifyadhocgroup.message.savednewgroup");
-        ra.addFlashAttribute("successArgs", new Object[]{ group.getTitle() });
-
-        boolean useAdhocUsers = Boolean.TRUE.equals(settings.get(EvalSettings.ENABLE_ADHOC_USERS));
-        if (!rejected.isEmpty()) {
-            ra.addFlashAttribute("errorMessage",
-                    useAdhocUsers ? "modifyadhocgroup.message.badusers" : "modifyadhocgroup.message.badusers.noadhocusers");
-            ra.addFlashAttribute("errorArgs", new Object[]{ String.join(", ", rejected) });
-        }
         if (!alreadyIn.isEmpty()) {
             ra.addFlashAttribute("infoMessage", "modifyadhocgroup.message.existingusers");
             ra.addFlashAttribute("infoArgs", new Object[]{ String.join(", ", alreadyIn) });
         }
 
         log.info("User ({}) saved adhoc group ({})", currentUserId, savedId);
-        return "redirect:/modify_adhoc_group?adhocGroupId=" + savedId
-                + (returnUrl.isEmpty() ? "" : "&returnUrl=" + URLEncoder.encode(returnUrl, StandardCharsets.UTF_8));
+        if (returnUrl.isEmpty()) {
+            ra.addFlashAttribute("successMessage", "controladhocgroups.group.saved");
+            ra.addFlashAttribute("successArgs", new Object[]{ group.getTitle() });
+            return "redirect:/control_adhoc_groups";
+        }
+        ra.addFlashAttribute("successMessage", "modifyadhocgroup.message.savednewgroup");
+        ra.addFlashAttribute("successArgs", new Object[]{ group.getTitle() });
+        return "redirect:" + returnUrl;
     }
 
     @PostMapping("/remove")
@@ -162,6 +201,11 @@ public class ModifyAdhocGroupController {
         EvalAdhocGroup group = commonLogic.getAdhocGroupById(adhocGroupId);
         if (!currentUserId.equals(group.getOwner()))
             throw new SecurityException("Only owners can modify adhocgroups: " + currentUserId);
+        if (isGroupLocked(group)) {
+            ra.addFlashAttribute("errorMessage", "controladhocgroups.group.locked.tooltip");
+            return "redirect:/modify_adhoc_group?adhocGroupId=" + adhocGroupId
+                    + (returnUrl.isEmpty() ? "" : "&returnUrl=" + URLEncoder.encode(returnUrl, StandardCharsets.UTF_8));
+        }
 
         List<String> participants = new ArrayList<>();
         for (String id : group.getParticipantIds()) {
@@ -231,5 +275,15 @@ public class ModifyAdhocGroupController {
             }
         }
         return toAdd;
+    }
+
+    private boolean isGroupLocked(EvalAdhocGroup group) {
+        List<EvalEvaluation> evals = evaluationService.getEvaluationsForEvalGroups(
+                new String[]{group.getEvalGroupId()}, 0, 0);
+        for (EvalEvaluation eval : evals) {
+            if (ControlAdhocGroupsController.isLockedState(evaluationService.updateEvaluationState(eval.getId())))
+                return true;
+        }
+        return false;
     }
 }

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/SakaiSkinInterceptor.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/SakaiSkinInterceptor.java
@@ -120,6 +120,9 @@ public class SakaiSkinInterceptor implements HandlerInterceptor {
             if (isAdmin || canBegin) {
                 items.add(new NavItem("/control_email_templates", "controlemailtemplates.page.title", currentPath.startsWith("/control_email_templates")));
             }
+            if (Boolean.TRUE.equals(evalSettings.get(EvalSettings.ENABLE_ADHOC_GROUPS)) && (isAdmin || canBegin)) {
+                items.add(new NavItem("/control_adhoc_groups", "controladhocgroups.page.title", currentPath.startsWith("/control_adhoc_groups")));
+            }
         }
         return items;
     }

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/templates/control_adhoc_groups.html
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/templates/control_adhoc_groups.html
@@ -1,0 +1,125 @@
+<!--
+
+    Copyright 2005 Sakai Foundation Licensed under the
+    Educational Community License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may
+    obtain a copy of the License at
+
+    http://www.osedu.org/licenses/ECL-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an "AS IS"
+    BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <title th:text="#{controladhocgroups.page.title}">My Adhoc Groups</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <script src="/library/js/headscripts.js" type="text/javascript"></script>
+    <link th:href="${skinRepo + '/tool_base.css'}" type="text/css" rel="stylesheet" media="screen"/>
+    <link th:href="${skinRepo + '/' + skinDefault + '/tool.css'}" type="text/css" rel="stylesheet" media="screen"/>
+    <link th:href="@{/content/css/evaluation_base.css}" type="text/css" rel="stylesheet" media="all"/>
+    <script src="/library/webjars/jquery/1.12.4/jquery.min.js"></script>
+    <script src="/library/webjars/jquery-ui/1.12.1/jquery-ui.min.js"></script>
+    <script src="/library/webjars/bootstrap/5.2.0/js/bootstrap.bundle.min.js"></script>
+    <script th:src="@{/content/js/utils.js}" type="text/javascript"></script>
+</head>
+<body>
+<div class="portletBody evaluation">
+
+    <ul th:replace="~{fragments/nav :: navbar}">nav</ul>
+
+    <ul class="breadCrumb">
+        <li>
+            <a th:href="@{/summary}" th:text="#{summary.page.title}">Summary</a>
+        </li>
+        <li class="lastCrumbNoFloat" th:text="#{controladhocgroups.page.title}">My Adhoc Groups</li>
+        <li class="lastCrumb">
+            <a th:href="@{/modify_adhoc_group}" class="addItem">
+                <span class="bi bi-plus-lg" aria-hidden="true"></span>
+                <span th:text="#{controladhocgroups.add.new.group.link}">Create a new Adhoc Group</span>
+            </a>
+        </li>
+    </ul>
+
+    <h3 th:text="#{controladhocgroups.page.title}">My Adhoc Groups</h3>
+    <p class="instructionText" th:text="#{controladhocgroups.page.instruction}">
+        Manage your adhoc groups. Groups used in active or closed evaluations cannot be modified.
+    </p>
+
+    <!-- Flash messages -->
+    <div th:if="${successMessage}" class="alertMessage successMessage">
+        <ul><li th:text="${successArgs != null} ? #{__${successMessage}__(${successArgs[0]})} : #{__${successMessage}__}">OK</li></ul>
+    </div>
+    <div th:if="${errorMessage}" class="alertMessage">
+        <ul><li th:text="${errorArgs != null} ? #{__${errorMessage}__(${errorArgs[0]})} : #{__${errorMessage}__}">Error</li></ul>
+    </div>
+    <div th:if="${infoMessage}" class="alertMessage informationMessage">
+        <ul><li th:text="${infoArgs != null} ? #{__${infoMessage}__(${infoArgs[0]})} : #{__${infoMessage}__}">Info</li></ul>
+    </div>
+
+    <p th:if="${#lists.isEmpty(groupRows)}" class="instructionText highlightPanel"
+       th:text="#{controladhocgroups.no.groups}">You have no adhoc groups yet.</p>
+
+    <table th:unless="${#lists.isEmpty(groupRows)}" class="evalsysTable" style="width:100%">
+        <thead>
+            <tr>
+                <th th:text="#{controladhocgroups.table.header.title}">Group Name</th>
+                <th th:text="#{controladhocgroups.table.header.members}">Members</th>
+                <th th:text="#{controladhocgroups.table.header.evaluations}">Evaluations</th>
+                <th class="screenOnly"></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr th:each="row : ${groupRows}">
+                <td th:text="${row.title}">Group Title</td>
+                <td th:text="${row.memberCount}">0</td>
+                <td>
+                    <span th:if="${#lists.isEmpty(row.evaluations)}"
+                          th:text="#{controladhocgroups.group.not.used}" class="inactive">—</span>
+                    <ul th:unless="${#lists.isEmpty(row.evaluations)}" style="margin:0;padding-left:1em">
+                        <li th:each="eval : ${row.evaluations}">
+                            <span th:text="${eval.title}">Eval title</span>
+                            (<span th:text="#{__${eval.stateKey}__}">state</span>)
+                            <span th:if="${eval.locked}" class="highlight" aria-hidden="true">&#x1F512;</span>
+                        </li>
+                    </ul>
+                </td>
+                <td class="screenOnly" style="white-space:nowrap">
+                    <!-- Edit -->
+                    <a th:if="${row.canEdit}"
+                       th:href="@{/modify_adhoc_group(adhocGroupId=${row.groupId})}"
+                       th:text="#{general.command.edit}">Edit</a>
+                    <span th:unless="${row.canEdit}"
+                          th:text="#{general.command.edit}"
+                          class="inactive"
+                          th:title="#{controladhocgroups.group.locked.tooltip}">Edit</span>
+                    <!-- Delete -->
+                    <form th:if="${row.canDelete}"
+                          th:action="@{/control_adhoc_groups/delete}" method="post"
+                          class="inlineForm left-separator"
+                          onsubmit="return confirm(this.dataset.confirm)"
+                          th:data-confirm="#{controladhocgroups.delete.confirm}">
+                        <input type="hidden" name="adhocGroupId" th:value="${row.groupId}"/>
+                        <input type="submit" th:value="#{general.command.delete}" class="makeLink"/>
+                    </form>
+                    <span th:unless="${row.canDelete}"
+                          th:text="#{general.command.delete}"
+                          class="inactive left-separator"
+                          th:title="#{controladhocgroups.cannot.delete.locked}">Delete</span>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+</div>
+<th:block th:if="${mainFrameId != ''}">
+    <script th:inline="javascript">setMainFrameHeight([[${mainFrameId}]]);</script>
+</th:block>
+</body>
+</html>

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/templates/modify_adhoc_group.html
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/templates/modify_adhoc_group.html
@@ -84,7 +84,7 @@
             </p>
 
             <p th:text="#{modifyadhocgroup.message.members}">Enter usernames or emails, one per line.</p>
-            <textarea name="newMembers" rows="5" cols="80"></textarea>
+            <textarea name="newMembers" rows="5" cols="80" th:text="${prefillMembers}"></textarea>
 
             <p>
                 <input type="submit" th:value="${isNew} ? #{modifyadhocgroup.newsave} : #{modifyadhocgroup.update}"
@@ -93,10 +93,8 @@
         </div>
     </form>
 
-    <!-- Back link to the wizard if returnUrl is provided -->
-    <a th:if="${returnUrl != null and !returnUrl.isEmpty()}"
-       th:href="${returnUrl}"
-       th:text="#{modifyadhocgroup.backtoevalassign}">Back to Evaluation Group Assignments</a>
+    <a th:href="${returnUrl != null and !#strings.isEmpty(returnUrl)} ? ${returnUrl} : @{/control_adhoc_groups}"
+       th:text="#{general.command.cancel}">Cancel</a>
 
 </div>
 <th:block th:if="${mainFrameId != ''}">


### PR DESCRIPTION
Adds a new /control_adhoc_groups page that lists all ad-hoc groups owned by the current user.  Groups used in active or closed evaluations are shown as read-only (edit/delete disabled) to avoid side-effects on ongoing surveys.

Changes:
- ControlAdhocGroupsController: new controller with listing, delete, and locked-state detection shared with ModifyAdhocGroupController
- control_adhoc_groups.html: new Thymeleaf template with group table, lock indicators, and flash messages
- SakaiSkinInterceptor: adds nav item when ENABLE_ADHOC_GROUPS is set
- ModifyAdhocGroupController: validates duplicate group names, rejects unknown users before saving (group not created on error), pre-fills the form on redirect, and returns to the listing after save
- modify_adhoc_group.html: cancel button always visible; textarea pre-filled after validation error
- messages.properties / messages_es_ES.properties: new i18n keys