### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout evaluation tool
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Checkout latest Sakai
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: sakaiproject/sakai
           ref: master
@@ -30,14 +30,14 @@ jobs:
           fetch-tags: false
 
       - name: Set up Temurin JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: temurin
           cache: maven
 
       - name: Set up Maven 3.9.9
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.9
 
@@ -62,7 +62,7 @@ jobs:
           mysql -u root -proot -e "DROP DATABASE IF EXISTS sakai; CREATE DATABASE sakai;"
 
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.m2/repository


### PR DESCRIPTION
## Summary

- Updates GitHub Actions references in `.github/workflows/maven.yml` to the latest published tags found from their upstream repositories.
- Moves `actions/checkout` from `v4` to `v7`.
- Moves `actions/setup-java` from `v4` to `v5`.
- Moves `stCarolas/setup-maven` from `v5` to `v5.1`.
- Moves `actions/cache` from `v4` to `v6`.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/maven.yml"); puts "YAML OK"'
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/maven.yml`
