### PR TITLE
Add missing English message bundle keys

### DIFF
--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages.properties
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages.properties
@@ -27,6 +27,7 @@ general.processing=Processing...
 general.no.button=No
 general.yes.button=Yes
 general.blank.required.field.user.message=You must fill in the {0}
+general.blank.required.field.user.message1=You must fill in the title
 general.confirm.action.item={0} item
 viewitem.na.desc=N/A
 viewitem.comment.desc=Comment:
@@ -305,6 +306,7 @@ controltemplates.template.inuse.note=Template is currently being used in at leas
 controltemplates.copy.user.message=Your template has been copied
 controltemplates.remove.user.message=Your template ({0}) has been removed
 controltemplates.chown.user.message=Your template ({0}) is now owned by {1}
+controltemplates.chown.nouser.message=No user was found matching the entered username or email.
 controltemplates.chown.permission.message=User {1} does not have permissions to be the owner of a template
 
 # Create template view
@@ -442,6 +444,9 @@ evalsettings.template.title.display=Template: {0}
 evalsettings.results.viewing.header=Evaluation results:
 evalsettings.results.viewing.sharing.header=Results sharing\: 
 evalsettings.results.viewable.admin.note=* Note that admins above in the hierarchy can view the results UNLESS results sharing is set to private
+evalsettings.results.sharing.note.private=Only the owner and administrators can view the results.
+evalsettings.results.sharing.note.visible=Results are visible according to the options configured below.
+evalsettings.results.sharing.note.public=Results are public and accessible to all assigned users, regardless of the options below.
 evalsettings.studentViewResults.label=Participants in the courses this evaluation is assigned to can view results
 evalsettings.studentViewResults.disabled=Results cannot be viewed by participants in the courses this evaluation is assigned to
 evalsettings.instructorViewResults.label=Instructors in the courses this evaluation is assigned to can view responses to questions about their own instruction.


### PR DESCRIPTION
## Summary
- Adds five message keys to `messages.properties` that were referenced by Thymeleaf templates and controllers after the Spring MVC migration (#179) but never defined in the default English bundle
- Fixes runtime `MissingResourceException` warnings on Evaluation Settings (results sharing notes) and related pages

Keys added:
- `evalsettings.results.sharing.note.private`, `.visible`, `.public` — dynamic help text for results sharing radio buttons
- `general.blank.required.field.user.message1` — title required validation on evaluation create
- `controltemplates.chown.nouser.message` — user-not-found error when changing template/evaluation owner

## Test plan
- [ ] Open Evaluation Settings for an evaluation and confirm no `evalsettings.results.sharing.note.*` warnings in the log
- [ ] Switch results sharing between Private / Visible / Public and confirm the italic note text updates below the radio buttons
- [ ] Submit Create Evaluation with an empty title and confirm the validation message displays correctly
- [ ] On Change Template Owner, enter an invalid username/email and confirm the error message displays instead of the raw key


Made with [Cursor](https://cursor.com)