### PR TITLE
EVALSYS-1445 Handle null instructor view-all results

### DIFF
--- a/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/logic/ReportingPermissions.java
+++ b/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/logic/ReportingPermissions.java
@@ -91,4 +91,15 @@ public interface ReportingPermissions {
     */
    public Set<String> getEvalGroupIdsForUserRole(Long evaluationId, String userId, String[] groupIds, boolean isUserInstructor);
 
+   /**
+    * Whether an admin or evaluatee may view instructor results based on settings and
+    * evaluation flags, without applying instructor view-date rules.
+    * Used by evaluation-list UI that shows report affordances before date checks.
+    *
+    * @param eval the evaluation
+    * @param userId internal user id
+    * @return true when the user may view as instructor ignoring dates
+    */
+   public boolean canViewResultsAsInstructorIgnoringDates(EvalEvaluation eval, String userId);
+
 }

--- a/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/model/EvalEvaluation.java
+++ b/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/model/EvalEvaluation.java
@@ -96,6 +96,10 @@ public class EvalEvaluation implements java.io.Serializable {
      */
     private boolean instructorViewResults;
 
+    /**
+     * Three-state authoring flag: {@code null} means unset (defaults may still apply).
+     * Decision paths must use {@link #isInstructorViewAllResultsEnabled()}, which treats null as false.
+     */
     private Boolean instructorViewAllResults;
 
     /**
@@ -1163,8 +1167,19 @@ public class EvalEvaluation implements java.io.Serializable {
         this.instructorViewResults = instructorViewResults;
     }
 
+    /**
+     * Three-state authoring value: {@code null} means unset (defaults may still apply).
+     * For permission and reporting decisions use {@link #isInstructorViewAllResultsEnabled()}.
+     */
     public Boolean getInstructorViewAllResults() {
         return instructorViewAllResults;
+    }
+
+    /**
+     * Whether instructors may view all results. Unset/{@code null} is treated as false.
+     */
+    public boolean isInstructorViewAllResultsEnabled() {
+        return Boolean.TRUE.equals(instructorViewAllResults);
     }
 
     public void setInstructorViewAllResults(Boolean instructorViewAllResults) {

--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImpl.java
@@ -1891,11 +1891,7 @@ public class EvalEvaluationSetupServiceImpl implements EvalEvaluationSetupServic
         if (eah.getInstructorsViewAllResults() == null) {
             Boolean instViewAllResults = (Boolean) settings.get(EvalSettings.INSTRUCTOR_ALLOWED_VIEW_ALL_RESULTS);
             if (instViewAllResults == null) {
-                if (Boolean.TRUE.equals(eval.getInstructorViewAllResults())) {
-                    eah.setInstructorsViewAllResults( Boolean.TRUE );
-                } else {
-                    eah.setInstructorsViewAllResults( Boolean.FALSE );
-                }
+                eah.setInstructorsViewAllResults(eval.isInstructorViewAllResultsEnabled());
             } else {
                 eah.setInstructorsViewAllResults(instViewAllResults);
             }

--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImpl.java
@@ -1891,7 +1891,7 @@ public class EvalEvaluationSetupServiceImpl implements EvalEvaluationSetupServic
         if (eah.getInstructorsViewAllResults() == null) {
             Boolean instViewAllResults = (Boolean) settings.get(EvalSettings.INSTRUCTOR_ALLOWED_VIEW_ALL_RESULTS);
             if (instViewAllResults == null) {
-                if (eval.getInstructorViewAllResults()) {
+                if (Boolean.TRUE.equals(eval.getInstructorViewAllResults())) {
                     eah.setInstructorsViewAllResults( Boolean.TRUE );
                 } else {
                     eah.setInstructorsViewAllResults( Boolean.FALSE );

--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/ReportingPermissionsImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/ReportingPermissionsImpl.java
@@ -277,7 +277,7 @@ public class ReportingPermissionsImpl implements ReportingPermissions {
             Boolean instructorAllowedViewResults = (Boolean) evalSettings.get(EvalSettings.INSTRUCTOR_ALLOWED_VIEW_RESULTS);
             if (instructorAllowedViewResults == null || instructorAllowedViewResults) {
                 boolean instructorViewResults = eval.getInstructorViewResults();
-                boolean instructorViewAllResults = eval.getInstructorViewAllResults();
+                boolean instructorViewAllResults = Boolean.TRUE.equals(eval.getInstructorViewAllResults());
                 if ((instructorViewResults && (userId.equals(eval.getOwner()) || isUserAdmin)) || instructorViewAllResults) {
                     Date checkDate = eval.getInstructorsDate();
                     if ( (checkDate == null && EvalUtils.checkStateAfter(eval.getState(), EvalConstants.EVALUATION_STATE_VIEWABLE, true))

--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/ReportingPermissionsImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/ReportingPermissionsImpl.java
@@ -274,18 +274,13 @@ public class ReportingPermissionsImpl implements ReportingPermissions {
         
         boolean allowedInstructor = false;
         if ( typeToEvalGroupId.containsKey(EvalAssignUser.TYPE_EVALUATEE) ) {
-            Boolean instructorAllowedViewResults = (Boolean) evalSettings.get(EvalSettings.INSTRUCTOR_ALLOWED_VIEW_RESULTS);
-            if (instructorAllowedViewResults == null || instructorAllowedViewResults) {
-                boolean instructorViewResults = eval.getInstructorViewResults();
-                boolean instructorViewAllResults = Boolean.TRUE.equals(eval.getInstructorViewAllResults());
-                if ((instructorViewResults && (userId.equals(eval.getOwner()) || isUserAdmin)) || instructorViewAllResults) {
-                    Date checkDate = eval.getInstructorsDate();
-                    if ( (checkDate == null && EvalUtils.checkStateAfter(eval.getState(), EvalConstants.EVALUATION_STATE_VIEWABLE, true))
-                            || (checkDate != null && (new Date()).after(checkDate)) 
-                            || (viewSurveyResultsIgnoreDates != null && viewSurveyResultsIgnoreDates)) {
-                        // user is allowed to view based on state and settings so check the groups below
-                        allowedInstructor = true;
-                    }
+            if (isInstructorResultsViewEnabled(eval, userId, isUserAdmin)) {
+                Date checkDate = eval.getInstructorsDate();
+                if ( (checkDate == null && EvalUtils.checkStateAfter(eval.getState(), EvalConstants.EVALUATION_STATE_VIEWABLE, true))
+                        || (checkDate != null && (new Date()).after(checkDate))
+                        || (viewSurveyResultsIgnoreDates != null && viewSurveyResultsIgnoreDates)) {
+                    // user is allowed to view based on state and settings so check the groups below
+                    allowedInstructor = true;
                 }
             }
 
@@ -328,6 +323,36 @@ public class ReportingPermissionsImpl implements ReportingPermissions {
         return viewableGroupIds;
     }
 
+    private boolean isInstructorResultsViewEnabled(EvalEvaluation eval, String userId, boolean isUserAdmin) {
+        Boolean instructorAllowedViewResults = (Boolean) evalSettings.get(EvalSettings.INSTRUCTOR_ALLOWED_VIEW_RESULTS);
+        if (instructorAllowedViewResults != null && !instructorAllowedViewResults) {
+            return false;
+        }
+        return (eval.getInstructorViewResults() && (userId.equals(eval.getOwner()) || isUserAdmin))
+                || eval.isInstructorViewAllResultsEnabled();
+    }
+
+    @Override
+    public boolean canViewResultsAsInstructorIgnoringDates(EvalEvaluation eval, String userId) {
+        if (eval == null || userId == null || "".equals(userId)) {
+            return false;
+        }
+        boolean isUserAdmin = commonLogic.isUserAdmin(userId);
+        if (!isInstructorResultsViewEnabled(eval, userId, isUserAdmin)) {
+            return false;
+        }
+        if (isUserAdmin) {
+            return true;
+        }
+        List<EvalAssignUser> userAssignments = evaluationService.getParticipantsForEval(
+                eval.getId(), userId, null, null, null, null, null);
+        for (EvalAssignUser eau : userAssignments) {
+            if (EvalAssignUser.TYPE_EVALUATEE.equals(eau.getType())) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * Gets the set of all evalGroupIds that are viewable by this user in this subset of groupIds for this evaluation

--- a/sakai-evaluation-impl/src/test/org/sakaiproject/evaluation/logic/ReportingPermissionsImplTest.java
+++ b/sakai-evaluation-impl/src/test/org/sakaiproject/evaluation/logic/ReportingPermissionsImplTest.java
@@ -190,6 +190,74 @@ public class ReportingPermissionsImplTest extends BaseTestEvalLogic {
    }
 
    @Test
+   public void testInstructorResultsView_nullInstructorViewAllResults() {
+      settings.set(EvalSettings.INSTRUCTOR_ALLOWED_VIEW_RESULTS, null);
+      settings.set(EvalSettings.STUDENT_ALLOWED_VIEW_RESULTS, null);
+
+      EvalEvaluation eval = evaluationService.getEvaluationById(etdl.evaluationClosed.getId());
+      eval.setState(EvalConstants.EVALUATION_STATE_VIEWABLE);
+      eval.setInstructorViewResults(false);
+      eval.setInstructorViewAllResults(null);
+      eval.setStudentViewResults(false);
+
+      Assert.assertFalse(eval.isInstructorViewAllResultsEnabled());
+      Assert.assertFalse(reportingPermissions.canViewResultsAsInstructorIgnoringDates(
+              eval, EvalTestDataLoad.MAINT_USER_ID));
+
+      Set<String> evalGroupIds = reportingPermissions.getViewableGroupsForEvalAndUserByRole(
+              eval, EvalTestDataLoad.MAINT_USER_ID, null);
+      Assert.assertNotNull(evalGroupIds);
+      Assert.assertEquals(0, evalGroupIds.size());
+
+      eval.setInstructorViewAllResults(true);
+      Assert.assertTrue(eval.isInstructorViewAllResultsEnabled());
+      Assert.assertTrue(reportingPermissions.canViewResultsAsInstructorIgnoringDates(
+              eval, EvalTestDataLoad.MAINT_USER_ID));
+
+      evalGroupIds = reportingPermissions.getViewableGroupsForEvalAndUserByRole(
+              eval, EvalTestDataLoad.MAINT_USER_ID, null);
+      Assert.assertNotNull(evalGroupIds);
+      Assert.assertEquals(1, evalGroupIds.size());
+   }
+
+   @Test
+   public void testInstructorResultsView_systemSettingDisabled() {
+      settings.set(EvalSettings.INSTRUCTOR_ALLOWED_VIEW_RESULTS, Boolean.FALSE);
+
+      EvalEvaluation eval = evaluationService.getEvaluationById(etdl.evaluationClosed.getId());
+      eval.setState(EvalConstants.EVALUATION_STATE_VIEWABLE);
+      eval.setInstructorViewResults(true);
+      eval.setInstructorViewAllResults(true);
+      eval.setStudentViewResults(false);
+
+      Assert.assertFalse(reportingPermissions.canViewResultsAsInstructorIgnoringDates(
+              eval, EvalTestDataLoad.MAINT_USER_ID));
+      Assert.assertFalse(reportingPermissions.canViewResultsAsInstructorIgnoringDates(
+              eval, EvalTestDataLoad.ADMIN_USER_ID));
+   }
+
+   @Test
+   public void testInstructorResultsView_ownerAndAdmin() {
+      settings.set(EvalSettings.INSTRUCTOR_ALLOWED_VIEW_RESULTS, null);
+
+      EvalEvaluation eval = evaluationService.getEvaluationById(etdl.evaluationClosed.getId());
+      eval.setState(EvalConstants.EVALUATION_STATE_VIEWABLE);
+      eval.setInstructorViewResults(true);
+      eval.setInstructorViewAllResults(false);
+      eval.setStudentViewResults(false);
+      eval.setOwner(EvalTestDataLoad.MAINT_USER_ID);
+
+      Assert.assertTrue(reportingPermissions.canViewResultsAsInstructorIgnoringDates(
+              eval, EvalTestDataLoad.MAINT_USER_ID));
+      Assert.assertTrue(reportingPermissions.canViewResultsAsInstructorIgnoringDates(
+              eval, EvalTestDataLoad.ADMIN_USER_ID));
+
+      // Non-owner without view-all is not enabled by flags alone
+      Assert.assertFalse(reportingPermissions.canViewResultsAsInstructorIgnoringDates(
+              eval, EvalTestDataLoad.USER_ID));
+   }
+
+   @Test
    public void testGetViewableGroupsForEvalAndUserByRole_activeIgnoreViewDates() {
 	  Set<String> evalGroupIds;
 	  EvalEvaluation eval;

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ControlEvaluationsController.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ControlEvaluationsController.java
@@ -32,7 +32,6 @@ import org.sakaiproject.evaluation.constant.EvalConstants;
 import org.sakaiproject.evaluation.logic.EvalSettings;
 import org.sakaiproject.evaluation.logic.entity.EvaluationEntityProvider;
 import org.sakaiproject.evaluation.model.EvalAssignGroup;
-import org.sakaiproject.evaluation.model.EvalAssignUser;
 import org.sakaiproject.evaluation.model.EvalEvaluation;
 import org.sakaiproject.evaluation.utils.EvalUtils;
 import org.springframework.context.MessageSource;
@@ -414,30 +413,11 @@ public class ControlEvaluationsController extends EvalControllerSupport {
         }
 
         if (!viewResultsEval) {
-            // Check if this user (instructor/evaluatee) has special permission
-            Boolean instructorAllowedViewResults = (Boolean) settings.get(EvalSettings.INSTRUCTOR_ALLOWED_VIEW_RESULTS);
-            boolean instructorViewResults = (instructorAllowedViewResults == null || instructorAllowedViewResults);
-
-            if (instructorViewResults) {
-                List<EvalAssignUser> userAssignments = evaluationService.getParticipantsForEval(
-                        eval.getId(), currentUserId, null, null, null, null, null);
-                boolean isEvaluatee = false;
-                for (EvalAssignUser eau : userAssignments) {
-                    if (EvalAssignUser.TYPE_EVALUATEE.equals(eau.getType())) {
-                        isEvaluatee = true;
-                        break;
-                    }
-                }
-                if (isEvaluatee || isUserAdmin) {
-                    if ((eval.getInstructorViewResults() &&
-                            (eval.getOwner().equals(currentUserId) || isUserAdmin)) ||
-                            eval.getInstructorViewAllResults()) {
-                        viewResultsEval = true;
-                        if (eval.getInstructorsDate() != null) {
-                            viewDate = eval.getInstructorsDate();
-                            viewableDate = df.format(viewDate);
-                        }
-                    }
+            if (reportingPermissions.canViewResultsAsInstructorIgnoringDates(eval, currentUserId)) {
+                viewResultsEval = true;
+                if (eval.getInstructorsDate() != null) {
+                    viewDate = eval.getInstructorsDate();
+                    viewableDate = df.format(viewDate);
                 }
             }
         }

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ReportViewController.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ReportViewController.java
@@ -35,6 +35,7 @@ import org.sakaiproject.evaluation.model.EvalEvaluation;
 import org.sakaiproject.evaluation.model.EvalScale;
 import org.sakaiproject.evaluation.model.EvalTemplateItem;
 import org.sakaiproject.evaluation.tool.EvalToolConstants;
+import org.sakaiproject.evaluation.tool.reporting.ReportItemVisibility;
 import org.sakaiproject.evaluation.tool.utils.EvalResponseAggregatorUtil;
 import org.sakaiproject.evaluation.tool.utils.RenderingUtils;
 import org.sakaiproject.evaluation.tool.utils.RenderingUtils.AnswersMean;
@@ -206,26 +207,27 @@ public class ReportViewController extends EvalControllerSupport {
         int totalTextResponses = 0;
         int renderedItemCount = 0;
 
-        Boolean instructorViewAllResults = evaluation.getInstructorViewAllResults() == null
-                ? Boolean.FALSE : evaluation.getInstructorViewAllResults();
         boolean useCourseOnly = !Boolean.FALSE.equals(settings.get(EvalSettings.ITEM_USE_COURSE_CATEGORY_ONLY));
+        boolean isCurrentUserAdmin = commonLogic.isUserAdmin(currentUserId);
 
         for (TemplateItemGroup tig : tidl.getTemplateItemGroups()) {
-            if (!renderAnyForUser(tig.getTemplateItems(), commonLogic.getEvalUserById(tig.associateId),
-                    evaluation.getOwner(), instructorViewAllResults, currentUserId)) {
+            if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                    currentUserId, tig.associateType, tig.associateId)
+                    || !renderAny(tig.getTemplateItems(), false)) {
                 continue;
             }
 
+            EvalUser associatedUser = commonLogic.getEvalUserById(tig.associateId);
             String headerKey = null;
             String headerArg = null;
             if (EvalConstants.ITEM_CATEGORY_COURSE.equals(tig.associateType) && !useCourseOnly) {
                 headerKey = "viewreport.itemlist.course";
             } else if (EvalConstants.ITEM_CATEGORY_INSTRUCTOR.equals(tig.associateType)) {
                 headerKey = "viewreport.itemlist.instructor";
-                headerArg = commonLogic.getEvalUserById(tig.associateId).displayName;
+                headerArg = associatedUser.displayName;
             } else if (EvalConstants.ITEM_CATEGORY_ASSISTANT.equals(tig.associateType)) {
                 headerKey = "viewreport.itemlist.ta";
-                headerArg = commonLogic.getEvalUserById(tig.associateId).displayName;
+                headerArg = associatedUser.displayName;
             }
 
             List<ItemResult> sectionItems = new ArrayList<>();
@@ -505,18 +507,6 @@ public class ReportViewController extends EvalControllerSupport {
             title = title.substring(0, EvalToolConstants.EVAL_REPORTING_MAX_NAME_LENGTH);
         }
         return Validator.escapeZipEntry(title);
-    }
-
-    private boolean renderAnyForUser(List<EvalTemplateItem> items, EvalUser associatedUser,
-                                     String owner, Boolean instructorViewAll, String currentUserId) {
-        if (!"invalid:null".equals(associatedUser.userId)
-                && !commonLogic.isUserAdmin(currentUserId)
-                && !currentUserId.equals(owner)
-                && !Boolean.TRUE.equals(instructorViewAll)
-                && !currentUserId.equals(associatedUser.userId)) {
-            return false;
-        }
-        return renderAny(items, false);
     }
 
     private boolean renderAny(List<EvalTemplateItem> items, boolean allEssays) {

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/CSVReportExporter.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/CSVReportExporter.java
@@ -120,7 +120,7 @@ public class CSVReportExporter implements ReportExporter {
             String evalTitle = evaluation.getTitle().replaceAll( " ", "_" );
 
             // Get permission to view, current user and eval owner
-            Boolean instructorViewAllResults = evaluation.getInstructorViewAllResults();
+            boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
             String currentUserID = commonLogic.getCurrentUserId();
             String evalOwner = evaluation.getOwner();
 
@@ -406,7 +406,7 @@ public class CSVReportExporter implements ReportExporter {
             OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
             CSVWriter writer = new CSVWriter(outputStreamWriter, COMMA, CSVWriter.DEFAULT_QUOTE_CHARACTER, CSVWriter.DEFAULT_ESCAPE_CHARACTER, CSVWriter.DEFAULT_LINE_END);
 
-            Boolean instructorViewAllResults = (boolean) evaluation.getInstructorViewAllResults();
+            boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
             String currentUserId = commonLogic.getCurrentUserId();
             String evalOwner = evaluation.getOwner();
 

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/CSVReportExporter.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/CSVReportExporter.java
@@ -120,9 +120,8 @@ public class CSVReportExporter implements ReportExporter {
             String evalTitle = evaluation.getTitle().replaceAll( " ", "_" );
 
             // Get permission to view, current user and eval owner
-            boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
             String currentUserID = commonLogic.getCurrentUserId();
-            String evalOwner = evaluation.getOwner();
+            boolean isCurrentUserAdmin = commonLogic.isUserAdmin(currentUserID);
 
             // Get the TIDL and DTIs for this evaluation
             TemplateItemDataList tidl = responseAggregator.prepareTemplateItemDataStructure( evaluation.getId(), groupIDs );
@@ -155,7 +154,8 @@ public class CSVReportExporter implements ReportExporter {
             for( DataTemplateItem dti : dtiList )
             {
                 // Skip items that aren't for the current user
-                if( isItemNotForCurrentUser( instructorViewAllResults, currentUserID, evalOwner, dti ) )
+                if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                        currentUserID, dti.associateType, dti.associateId))
                 {
                     continue;
                 }
@@ -211,7 +211,8 @@ public class CSVReportExporter implements ReportExporter {
                 for( DataTemplateItem dti : dtiList )
                 {
                     // Skip items that aren't for the current user
-                    if( isItemNotForCurrentUser( instructorViewAllResults, currentUserID, evalOwner, dti ) )
+                    if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                            currentUserID, dti.associateType, dti.associateId))
                     {
                         continue;
                     }
@@ -362,23 +363,6 @@ public class CSVReportExporter implements ReportExporter {
         catch( IOException ex ) { throw new RuntimeException("Could not close the ZipOutputStream" ,  ex); }
     }
 
-    /**
-     * Determine if the current DataTemplateItem should be included in the report (for the current user)
-     * @param instructorViewAllResults
-     * @param currentUserID
-     * @param evalOwner
-     * @param dti
-     * @return true if the item is for the current user; false otherwise
-     */
-    private boolean isItemNotForCurrentUser( boolean instructorViewAllResults, String currentUserID, String evalOwner, DataTemplateItem dti )
-    {
-        return !instructorViewAllResults                                                       // If the eval is so configured,
-                && !commonLogic.isUserAdmin( currentUserID )                                  // and currentUser is not an admin
-                && !currentUserID.equals( evalOwner )                                         // and currentUser is not the eval creator
-                && !EvalConstants.ITEM_CATEGORY_COURSE.equals( dti.associateType )            // and the associate type is not 'course'
-                && !currentUserID.equals( commonLogic.getEvalUserById( dti.associateId ).userId );
-    }
-
     /* (non-Javadoc)
      * @see org.sakaiproject.evaluation.tool.reporting.ReportExporter#buildReport(org.sakaiproject.evaluation.model.EvalEvaluation, java.lang.String[], java.io.OutputStream)
      */
@@ -406,9 +390,7 @@ public class CSVReportExporter implements ReportExporter {
             OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
             CSVWriter writer = new CSVWriter(outputStreamWriter, COMMA, CSVWriter.DEFAULT_QUOTE_CHARACTER, CSVWriter.DEFAULT_ESCAPE_CHARACTER, CSVWriter.DEFAULT_LINE_END);
 
-            boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
             String currentUserId = commonLogic.getCurrentUserId();
-            String evalOwner = evaluation.getOwner();
 
             boolean isCurrentUserAdmin = commonLogic.isUserAdmin(currentUserId);
 
@@ -424,11 +406,8 @@ public class CSVReportExporter implements ReportExporter {
             List<String> questionTextRow = new ArrayList<>();
             for (DataTemplateItem dti : dtiList) {
 
-                if (!instructorViewAllResults // If the eval is so configured,
-                  && !isCurrentUserAdmin // and currentUser is not an admin
-                  && !currentUserId.equals(evalOwner) // and currentUser is not the eval creator
-                  && !EvalConstants.ITEM_CATEGORY_COURSE.equals(dti.associateType)
-                  && !currentUserId.equals(commonLogic.getEvalUserById(dti.associateId).userId) ) {
+                if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                        currentUserId, dti.associateType, dti.associateId)) {
                     //skip instructor items that aren't for the current user
                     continue;
                 }
@@ -474,11 +453,8 @@ public class CSVReportExporter implements ReportExporter {
                 List<String> nextResponseRow = new ArrayList<>();
                 for (DataTemplateItem dti : dtiList) {
 
-                    if (!instructorViewAllResults // If the eval is so configured,
-                      && !isCurrentUserAdmin // and currentUser is not an admin
-                      && !currentUserId.equals(evalOwner) // and currentUser is not the eval creator
-                      && !EvalConstants.ITEM_CATEGORY_COURSE.equals(dti.associateType)
-                      && !currentUserId.equals(commonLogic.getEvalUserById(dti.associateId).userId) ) {
+                    if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                            currentUserId, dti.associateType, dti.associateId)) {
                         //skip instructor items that aren't for the current user
                         continue;
                     }

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporter.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporter.java
@@ -112,7 +112,7 @@ public class PDFReportExporter implements ReportExporter {
         //Make sure responseAggregator is using this message source
         responseAggregator.setMessageSource(messages);
         EvalPDFReportBuilder evalPDFReportBuilder = new EvalPDFReportBuilder(outputStream);
-        Boolean instructorViewAllResults = (boolean) evaluation.getInstructorViewAllResults();
+        boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
         String currentUserId = commonLogic.getCurrentUserId();
         String evalOwner = evaluation.getOwner();
 

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporter.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporter.java
@@ -112,9 +112,7 @@ public class PDFReportExporter implements ReportExporter {
         //Make sure responseAggregator is using this message source
         responseAggregator.setMessageSource(messages);
         EvalPDFReportBuilder evalPDFReportBuilder = new EvalPDFReportBuilder(outputStream);
-        boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
         String currentUserId = commonLogic.getCurrentUserId();
-        String evalOwner = evaluation.getOwner();
 
         boolean isCurrentUserAdmin = commonLogic.isUserAdmin(currentUserId);
 
@@ -174,11 +172,8 @@ public class PDFReportExporter implements ReportExporter {
         // Loop through the major group types: Course Questions, Instructor Questions, etc.
         for (TemplateItemGroup tig : tidl.getTemplateItemGroups()) {
 
-            if (!instructorViewAllResults   // If the eval is so configured,
-              && !isCurrentUserAdmin // and currentUser is not an admin
-              && !currentUserId.equals(evalOwner) // and currentUser is not the eval creator
-              && !EvalConstants.ITEM_CATEGORY_COURSE.equals(tig.associateType)
-              && !currentUserId.equals(commonLogic.getEvalUserById(tig.associateId).userId) ) {
+            if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                    currentUserId, tig.associateType, tig.associateId)) {
                 // skip items that aren't for the current user
                 continue;
             }
@@ -220,11 +215,8 @@ public class PDFReportExporter implements ReportExporter {
                     log.debug("Item text: "+dti.templateItem.getItem().getItemText());
 
 
-                    if (!instructorViewAllResults // If the eval is so configured,
-                      && !isCurrentUserAdmin  // and currentUser is not an admin
-                      && !currentUserId.equals(evalOwner) // and currentUser is not the eval creator
-                      && !EvalConstants.ITEM_CATEGORY_COURSE.equals(dti.associateType)
-                      && !currentUserId.equals(commonLogic.getEvalUserById(dti.associateId).userId) ) {
+                    if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                            currentUserId, dti.associateType, dti.associateId)) {
                         //skip instructor items that aren't for the current user
                         continue;
                     }

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporterIndividual.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporterIndividual.java
@@ -110,7 +110,7 @@ public class PDFReportExporterIndividual implements ReportExporter {
         //Make sure responseAggregator is using this message source
         responseAggregator.setMessageSource(messages);
 		EvalPDFReportBuilder evalPDFReportBuilder = new EvalPDFReportBuilder(outputStream);
-        Boolean instructorViewAllResults = (boolean) evaluation.getInstructorViewAllResults();
+        boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
         String currentUserId = commonLogic.getCurrentUserId();
         String evalOwner = evaluation.getOwner();
 

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporterIndividual.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporterIndividual.java
@@ -110,9 +110,8 @@ public class PDFReportExporterIndividual implements ReportExporter {
         //Make sure responseAggregator is using this message source
         responseAggregator.setMessageSource(messages);
 		EvalPDFReportBuilder evalPDFReportBuilder = new EvalPDFReportBuilder(outputStream);
-        boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
         String currentUserId = commonLogic.getCurrentUserId();
-        String evalOwner = evaluation.getOwner();
+        boolean isCurrentUserAdmin = commonLogic.isUserAdmin(currentUserId);
 
         Boolean useBannerImage = (Boolean) evalSettings.get(EvalSettings.ENABLE_PDF_REPORT_BANNER);
         byte[] bannerImageBytes = null;
@@ -170,11 +169,8 @@ public class PDFReportExporterIndividual implements ReportExporter {
         // Loop through the major group types: Course Questions, Instructor Questions, etc.
         for (TemplateItemGroup tig : tidl.getTemplateItemGroups()) {
 
-            if (!instructorViewAllResults   // If the eval is so configured,
-              && !commonLogic.isUserAdmin(currentUserId) // and currentUser is not an admin
-              && !currentUserId.equals(evalOwner) // and currentUser is not the eval creator
-              && !EvalConstants.ITEM_CATEGORY_COURSE.equals(tig.associateType)
-              && !currentUserId.equals(commonLogic.getEvalUserById(tig.associateId).userId) ) {
+            if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                    currentUserId, tig.associateType, tig.associateId)) {
                 // skip items that aren't for the current user
                 continue;
             }
@@ -220,11 +216,8 @@ public class PDFReportExporterIndividual implements ReportExporter {
                     DataTemplateItem dti = dtis.get(i);
                     log.debug("Item text: "+dti.templateItem.getItem().getItemText());
 
-                    if (!instructorViewAllResults // If the eval is so configured,
-                      && !commonLogic.isUserAdmin(currentUserId)  // and currentUser is not an admin
-                      && !currentUserId.equals(evalOwner) // and currentUser is not the eval creator
-                      && !EvalConstants.ITEM_CATEGORY_COURSE.equals(dti.associateType)
-                      && !currentUserId.equals(commonLogic.getEvalUserById(dti.associateId).userId) ) {
+                    if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                            currentUserId, dti.associateType, dti.associateId)) {
                         //skip instructor items that aren't for the current user
                         continue;
                     }

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/ReportItemVisibility.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/ReportItemVisibility.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2005 Sakai Foundation Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.sakaiproject.evaluation.tool.reporting;
+
+import org.sakaiproject.evaluation.constant.EvalConstants;
+import org.sakaiproject.evaluation.model.EvalEvaluation;
+
+/**
+ * Shared visibility rules for report views and exporters when instructors may
+ * only see their own associated items.
+ */
+public final class ReportItemVisibility {
+
+    private ReportItemVisibility() {
+    }
+
+    /**
+     * Whether the viewer may see report items for this associate (instructor, TA, or course).
+     *
+     * @param evaluation the evaluation being reported
+     * @param viewerIsAdmin whether the viewer is a system admin
+     * @param viewerUserId internal user id of the viewer
+     * @param associateType template item category (course/instructor/assistant)
+     * @param associateUserId associate user id, or null when unset
+     * @return true when the viewer may see this associate's items
+     */
+    public static boolean isVisibleToViewer(EvalEvaluation evaluation, boolean viewerIsAdmin,
+            String viewerUserId, String associateType, String associateUserId) {
+        if (evaluation.isInstructorViewAllResultsEnabled()
+                || viewerIsAdmin
+                || viewerUserId.equals(evaluation.getOwner())) {
+            return true;
+        }
+        if (EvalConstants.ITEM_CATEGORY_COURSE.equals(associateType)) {
+            return true;
+        }
+        if (associateUserId == null) {
+            return true;
+        }
+        return viewerUserId.equals(associateUserId);
+    }
+}

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/XLSReportExporter.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/XLSReportExporter.java
@@ -108,9 +108,8 @@ public class XLSReportExporter implements ReportExporter {
     private void buildReportSectionAware( EvalEvaluation evaluation, String[] groupIDs, OutputStream outputStream )
     {
         // Get permission to view, current user and eval owner
-        boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
         String currentUserId = commonLogic.getCurrentUserId();
-        String evalOwner = evaluation.getOwner();
+        boolean isCurrentUserAdmin = commonLogic.isUserAdmin(currentUserId);
 
         TemplateItemDataList tidl = getEvalTIDL( evaluation, groupIDs );
         List<DataTemplateItem> dtiList = tidl.getFlatListOfDataTemplateItems( true );
@@ -238,7 +237,8 @@ public class XLSReportExporter implements ReportExporter {
         for( DataTemplateItem dti : dtiList )
         {
             // Skip items that aren't for the current user
-            if( isItemNotForCurrentUser( instructorViewAllResults, currentUserId, evalOwner, dti ) )
+            if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                    currentUserId, dti.associateType, dti.associateId))
             {
                 continue;
             }
@@ -301,7 +301,8 @@ public class XLSReportExporter implements ReportExporter {
             for( DataTemplateItem dti : dtiList )
             {
                 // Skip items that aren't for the current user
-                if( isItemNotForCurrentUser( instructorViewAllResults, currentUserId, evalOwner, dti ) )
+                if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                        currentUserId, dti.associateType, dti.associateId))
                 {
                     continue;
                 }
@@ -470,23 +471,6 @@ public class XLSReportExporter implements ReportExporter {
 
     }
 
-    /**
-     * Determine if the current DataTemplateItem should be included in the report (for the current user)
-     * @param instructorViewAllResults
-     * @param currentUserID
-     * @param evalOwner
-     * @param dti
-     * @return true if the item is for the current user; false otherwise
-     */
-    private boolean isItemNotForCurrentUser( boolean instructorViewAllResults, String currentUserID, String evalOwner, DataTemplateItem dti )
-    {
-        return !instructorViewAllResults                                                       // If the eval is so configured,
-                && !commonLogic.isUserAdmin( currentUserID )                                  // and currentUser is not an admin
-                && !currentUserID.equals( evalOwner )                                         // and currentUser is not the eval creator
-                && !EvalConstants.ITEM_CATEGORY_COURSE.equals( dti.associateType )            // and the associate type is not 'course'
-                && !currentUserID.equals( commonLogic.getEvalUserById( dti.associateId ).userId );
-    }
-
     /*
      * (non-Javadoc)
      *
@@ -525,9 +509,7 @@ public class XLSReportExporter implements ReportExporter {
         }
         else
         {
-            boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
             String currentUserId = commonLogic.getCurrentUserId();
-            String evalOwner = evaluation.getOwner();
 
             boolean isCurrentUserAdmin = commonLogic.isUserAdmin(currentUserId);
 
@@ -612,11 +594,8 @@ public class XLSReportExporter implements ReportExporter {
            short headerCount = 1;
            for (DataTemplateItem dti : dtiList) {
 
-               if (!instructorViewAllResults // If the eval is so configured,
-                 && !isCurrentUserAdmin // and currentUser is not an admin
-                 && !currentUserId.equals(evalOwner) // and currentUser is not the eval creator
-                 && !EvalConstants.ITEM_CATEGORY_COURSE.equals(dti.associateType)
-                 && !currentUserId.equals(commonLogic.getEvalUserById(dti.associateId).userId) ) {
+               if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                       currentUserId, dti.associateType, dti.associateId)) {
                    // skip items that aren't for the current user
                    continue;
                }
@@ -675,11 +654,8 @@ public class XLSReportExporter implements ReportExporter {
                short dtiCounter = 1;
                for (DataTemplateItem dti : dtiList) {
 
-                   if (!instructorViewAllResults // If the eval is so configured,
-                     && !isCurrentUserAdmin // and currentUser is not an admin
-                     && !currentUserId.equals(evalOwner) // and currentUser is not the eval creator
-                     && !EvalConstants.ITEM_CATEGORY_COURSE.equals(dti.associateType)
-                     && !currentUserId.equals(commonLogic.getEvalUserById(dti.associateId).userId) ) {
+                   if (!ReportItemVisibility.isVisibleToViewer(evaluation, isCurrentUserAdmin,
+                           currentUserId, dti.associateType, dti.associateId)) {
                        //skip instructor items that aren't for the current user
                        continue;
                    }

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/XLSReportExporter.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/XLSReportExporter.java
@@ -108,7 +108,7 @@ public class XLSReportExporter implements ReportExporter {
     private void buildReportSectionAware( EvalEvaluation evaluation, String[] groupIDs, OutputStream outputStream )
     {
         // Get permission to view, current user and eval owner
-        Boolean instructorViewAllResults = evaluation.getInstructorViewAllResults();
+        boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
         String currentUserId = commonLogic.getCurrentUserId();
         String evalOwner = evaluation.getOwner();
 
@@ -525,7 +525,7 @@ public class XLSReportExporter implements ReportExporter {
         }
         else
         {
-            Boolean instructorViewAllResults = (boolean) evaluation.getInstructorViewAllResults();
+            boolean instructorViewAllResults = Boolean.TRUE.equals(evaluation.getInstructorViewAllResults());
             String currentUserId = commonLogic.getCurrentUserId();
             String evalOwner = evaluation.getOwner();
 

--- a/sakai-evaluation-tool/src/test/org/sakaiproject/evaluation/tool/reporting/ReportItemVisibilityTest.java
+++ b/sakai-evaluation-tool/src/test/org/sakaiproject/evaluation/tool/reporting/ReportItemVisibilityTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2005 Sakai Foundation Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.sakaiproject.evaluation.tool.reporting;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.sakaiproject.evaluation.constant.EvalConstants;
+import org.sakaiproject.evaluation.model.EvalEvaluation;
+
+/**
+ * Unit tests for {@link ReportItemVisibility}.
+ */
+public class ReportItemVisibilityTest {
+
+    @Test
+    public void isVisibleToViewer_hidesOtherInstructorWhenViewAllDisabled() {
+        EvalEvaluation eval = evaluation(false);
+        Assert.assertFalse(ReportItemVisibility.isVisibleToViewer(
+                eval, false, "viewer", EvalConstants.ITEM_CATEGORY_INSTRUCTOR, "other-instructor"));
+    }
+
+    @Test
+    public void isVisibleToViewer_showsCourseAndOwnItems() {
+        EvalEvaluation eval = evaluation(false);
+        Assert.assertTrue(ReportItemVisibility.isVisibleToViewer(
+                eval, false, "viewer", EvalConstants.ITEM_CATEGORY_COURSE, "anything"));
+        Assert.assertTrue(ReportItemVisibility.isVisibleToViewer(
+                eval, false, "viewer", EvalConstants.ITEM_CATEGORY_INSTRUCTOR, "viewer"));
+        Assert.assertTrue(ReportItemVisibility.isVisibleToViewer(
+                eval, false, "viewer", EvalConstants.ITEM_CATEGORY_INSTRUCTOR, null));
+    }
+
+    @Test
+    public void isVisibleToViewer_viewAllAdminOrOwnerSeeAll() {
+        Assert.assertTrue(ReportItemVisibility.isVisibleToViewer(
+                evaluation(true), false, "viewer", EvalConstants.ITEM_CATEGORY_INSTRUCTOR, "other"));
+        Assert.assertTrue(ReportItemVisibility.isVisibleToViewer(
+                evaluation(false), true, "viewer", EvalConstants.ITEM_CATEGORY_INSTRUCTOR, "other"));
+        Assert.assertTrue(ReportItemVisibility.isVisibleToViewer(
+                evaluation(false), false, "owner", EvalConstants.ITEM_CATEGORY_INSTRUCTOR, "other"));
+    }
+
+    @Test
+    public void isVisibleToViewer_treatsNullViewAllAsFalse() {
+        EvalEvaluation eval = evaluation(false);
+        eval.setInstructorViewAllResults(null);
+        Assert.assertFalse(eval.isInstructorViewAllResultsEnabled());
+        Assert.assertFalse(ReportItemVisibility.isVisibleToViewer(
+                eval, false, "viewer", EvalConstants.ITEM_CATEGORY_INSTRUCTOR, "other"));
+    }
+
+    private EvalEvaluation evaluation(boolean instructorViewAllResults) {
+        EvalEvaluation eval = new EvalEvaluation();
+        eval.setOwner("owner");
+        eval.setInstructorViewAllResults(instructorViewAllResults);
+        return eval;
+    }
+}


### PR DESCRIPTION
## Summary

Treat null `EvalEvaluation.instructorViewAllResults` values as false in report export and reporting permission paths.

This prevents legacy rows with `EVAL_EVALUATION.INSTRUCTOR_VIEW_ALL_RESULTS = NULL` from throwing when PDF reports, individual PDF reports, CSV/XLS report paths, or related reporting permission logic unbox the nullable Boolean.

## Root cause

The database column and Hibernate mapping allow null, but several consumers directly unboxed `getInstructorViewAllResults()`. Existing defaults cover many newly saved evaluations, but legacy null values can still reach report generation.

## Validation

- `mvn -pl sakai-evaluation-impl,sakai-evaluation-tool -am -DskipTests compile`
