### PR TITLE
EVALSYS-1612 Reschedule results-available email when an evaluation is closed early

### DIFF
--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/scheduling/EvalJobLogicImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/scheduling/EvalJobLogicImpl.java
@@ -367,6 +367,13 @@ public class EvalJobLogicImpl implements EvalJobLogic {
             checkInvocationDate(eval, EvalConstants.JOB_TYPE_CLOSED, eval.getStopDate());
 
         } else if (EvalConstants.EVALUATION_STATE_CLOSED.equals(eval.getState())) {
+            // Reaching CLOSED (e.g. via an early manual close) can leave stale DUE/CLOSED
+            // jobs behind from the normal state cascade (ACTIVE -> DUE -> CLOSED -> VIEWABLE).
+            // If left in place, they fire later using an out-of-date schedule and re-derive
+            // the VIEWABLE job from the original due date instead of the actual close time.
+            deleteInvocation(eval.getId(), EvalConstants.JOB_TYPE_DUE);
+            deleteInvocation(eval.getId(), EvalConstants.JOB_TYPE_CLOSED);
+
             // make sure scheduleView job invocation start date matches EvalEvaluation view date
             checkInvocationDate(eval, EvalConstants.JOB_TYPE_VIEWABLE, eval.getViewDate());
 
@@ -458,9 +465,15 @@ public class EvalJobLogicImpl implements EvalJobLogic {
         // get the jobs for this eval
         EvalScheduledJob[] jobs = commonLogic.findScheduledJobs(eval.getId(), jobType);
 
-        // if there are no invocations, return
         if (jobs.length == 0) {
-            // FIXME why return here? if no job was found should we not create one? -AZ
+            // no invocation exists yet for this jobType (e.g. the normal state cascade was
+            // skipped by an early manual close) -- create one so the eval and its schedule
+            // stay in sync instead of silently never notifying anyone
+            String newJobId = commonLogic.createScheduledJob(correctDate, eval.getId(), jobType);
+            if (log.isDebugEnabled()) {
+                log.debug("EvalJobLogicImpl.checkInvocationDate created a new invocation: "
+                        + newJobId + ", date=" + correctDate + "," + eval.getId() + "," + jobType + ")");
+            }
         } else {
             // we expect one delayed invocation matching componentId and opaqueContext so remove any extras
             cleanupExtraJobs(jobs);

--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/scheduling/EvalJobLogicImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/scheduling/EvalJobLogicImpl.java
@@ -470,10 +470,7 @@ public class EvalJobLogicImpl implements EvalJobLogic {
             // skipped by an early manual close) -- create one so the eval and its schedule
             // stay in sync instead of silently never notifying anyone
             String newJobId = commonLogic.createScheduledJob(correctDate, eval.getId(), jobType);
-            if (log.isDebugEnabled()) {
-                log.debug("EvalJobLogicImpl.checkInvocationDate created a new invocation: "
-                        + newJobId + ", date=" + correctDate + "," + eval.getId() + "," + jobType + ")");
-            }
+            log.debug("New invocation: jobId={}, date={}, evalId={}, type={}", newJobId, correctDate, eval.getId(), jobType);
         } else {
             // we expect one delayed invocation matching componentId and opaqueContext so remove any extras
             cleanupExtraJobs(jobs);


### PR DESCRIPTION
## Summary

Closing an evaluation manually before its scheduled due date ("Close Now") correctly moved `dueDate`/state to `CLOSED`, but left the pre-existing `JOB_TYPE_DUE` Quartz job in place and never created a `JOB_TYPE_VIEWABLE` job to notify participants that results are available. The results-available email ended up firing near the evaluation's *original* due date instead of shortly after the manual close, since the stale `DUE` job would eventually fire and rebuild the same `DUE -> CLOSED -> VIEWABLE` cascade using the original schedule.

- `EvalJobLogicImpl.checkInvocationDate()`: create the scheduled job when none exists yet for the requested `jobType`, instead of silently doing nothing (implements the existing `// FIXME why return here?` in the code).
- `EvalJobLogicImpl.processEvaluationChange()`: when an evaluation reaches `CLOSED` state, delete any stale `DUE`/`CLOSED` invocations left over from the normal cascade before checking/creating the `VIEWABLE` job, so they cannot re-fire later using the pre-close schedule.

Jira: https://sakaiproject.atlassian.net/browse/EVALSYS-1612

## Test plan

- [x] Verified live: created an evaluation with due date set a week out, closed it manually with "Close Now", and confirmed the results-available email was sent ~3 minutes after the manual close instead of waiting for the original due date (details in the Jira ticket).
- [ ] Not covered by an automated test: `MockEvalExternalLogic` (used by `EvalJobLogicImplTest`) doesn't implement `createScheduledJob`/`findScheduledJobs`/`deleteScheduledJob` (they throw `UnsupportedOperationException`), so this fix couldn't be unit tested without first building out that test fake. Tracked as separate follow-up work.