### PR TITLE
EVALSYS-1613 Comprehensive update of the Spanish (es_ES) translation

### DIFF
--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages_es_ES.properties
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages_es_ES.properties
@@ -3,11 +3,11 @@
 # Shared items
 no.list.items=No hay elementos que listar
 unknown.caps=DESCONOCIDO
-general.close.window.button=Cerrar Ventana
+general.close.window.button=Cerrar ventana
 general.back.button=Atr\u00E1s
 general.cancel.button=Cancelar
 general.submit.button=Enviar
-general.direct.link= Enlace Permanente
+general.direct.link=Enlace permanente
 general.direct.link.title=URL directa para acceso externo
 general.category.link.tip=url directa a la categor\u00EDa: {0}
 general.note=Nota
@@ -19,14 +19,14 @@ general.private=Privado
 general.command.edit=Editar
 general.command.delete=Eliminar
 general.command.cancel=Cancelar
-general.command.chown=Cambiar Propietario
+general.command.chown=Cambiar propiedad
 general.command.split.block=Separar este grupo en elementos individuales
-general.command.preview=Previsualizar
+general.command.preview=Vista previa
 general.copy=Copiar
 general.processing=Procesando...
 general.no.button=No
 general.yes.button=Si
-general.blank.required.field.user.message=Debe rellenar el campo que falta {0}
+general.blank.required.field.user.message=Debe rellenar el campo {0}
 general.confirm.action.item={0} elemento
 general.blank.required.field.user.message1=Debe rellenar el campo t\u00EDtulo
 general.blank.required.field.user.message2=Debe rellenar el campo elemento de texto 
@@ -34,17 +34,17 @@ general.blank.required.field.user.message3=Debe rellenar el campo fecha de inici
 viewitem.na.desc=N/A
 viewitem.comment.desc=Comentario:
 sharing.private=Privado - visible y editable s\u00F3lo por usted
-sharing.public=Publico - visible para todos, editable por cualquier administrador
+sharing.public=P\u00FAblico - visible para cualquiera, editable por cualquier administrador
 sharing.visible=Visible - visible para cualquier administrador, editable s\u00F3lo por usted
 sharing.shared=Compartido - para cualquier administrador, editable s\u00F3lo por administradores del mismo nivel que el propietario
 item.classification.scaled=Pregunta de escala
-item.classification.multichoice=Selecci\u00F3n M\u00FAltiple
-item.classification.multianswer=Respuesta M\u00FAltiple
-item.classification.text=Respuesta Corta/Ensayo
-item.classification.header=Cabecera de texto
+item.classification.multichoice=Pregunta de opci\u00F3n m\u00FAltiple
+item.classification.multianswer=Pregunta de respuesta m\u00FAltiple
+item.classification.text=Pregunta de texto libre
+item.classification.header=Cabecera
 item.classification.block=Bloque de preguntas
-item.classification.existing=Existente
-item.classification.expert=Experto
+item.classification.existing=A\u00F1adir desde Mis elementos
+item.classification.expert=A\u00F1adir desde elementos de Experto
 
 
 # Messages for the user
@@ -65,7 +65,7 @@ summary.evaluations.starts.title=Comienza
 summary.evaluations.ends.title=Finaliza
 summary.evaluations.none=No hay evaluaciones a realizar ahora mismo
 summary.evaluations.admin=Evaluaciones que est\u00E1 creando o administrando
-summary.sitelisting.title=Listar Sitio/Grupo
+summary.sitelisting.title=Listado de sitios/grupos
 summary.sitelisting.evaluated=Grupos en los que he evaluado:
 summary.sitelisting.evaluate=Grupos que puedo evaluar:
 summary.sitelisting.maxshown={0} grupos no mostrados
@@ -75,50 +75,50 @@ summary.eval.assigned.from.above=Se le ha asignado una evaluaci\u00F3n desde un 
 summary.tools.title=Herramientas de Evaluaci\u00F3n
 summary.header.status=Estado
 # printable text representing the status
-summary.status.InQueue=En cola
+summary.status.InQueue=En lista de espera
 summary.status.Active=Activa
 summary.status.Due=Vencida
 summary.status.Closed=Cerrada
-summary.status.Viewable=Respuestas Visibles
+summary.status.Viewable=Respuestas visibles
 # printable text representing the label in front of the date for this status (label: date)
 summary.label.starts=Empezada
 summary.label.due=Vencida
-summary.label.nevercloses=Sin L\u00EDmite
+summary.label.nevercloses=Sin l\u00EDmite
 summary.label.gracetill=Cerrada
 summary.label.resultsviewableon=Visible
 summary.label.resultsviewablesince=Visible desde
 summary.label.fallback=Empezada
 
-summary.label.InQueue=Empezada
-summary.label.Active=Activa
-summary.label.Due=Vencida
-summary.label.Closed=Cerrada
-summary.label.Viewable=Respuestas Visibles
+summary.label.InQueue=Empieza
+summary.label.Active=Vence
+summary.label.Due=Se cierra
+summary.label.Closed=Visible
+summary.label.Viewable=Visible desde
 
 # Administrate view
 administrate.page.title=Administrar
-administrate.version.revision= Versi\u00F3n Aplic. : {0} - SVN: {1} - \u00DAltima modificaci\u00F3n: {2}
-administrate.system.settings.header=Ajustes del Sistema
+administrate.version.revision=Versi\u00F3n Aplic. : {0} - SVN: {1} - \u00FAltima modificaci\u00F3n: {2}
+administrate.system.settings.header=Ajustes del sistema
 administrate.system.settings.instructions= Dese cuenta que los ajustes de sistemas permiten mayor control sobre lo que pueda suceder. Los ajustes de la evaluaci\u00F3n pueden permancer controlados desde la base de la evaluaci\u00F3n a menos que estos se reescriban aqu\u00ED.
-administrate.instructor.settings.header=Ajustes profesor:
+administrate.instructor.settings.header=Ajustes del profesor:
 administrate.instructors.eval.create.note=Los Profesores tienen permitido crear nuevas evaluaciones.
-administrate.instructors.view.results.note=Los Profesores pueden ver los resultados
-administrate.instructors.email.students.note=Los Profesores pueden enviar correos electr\u00F3nicos a los estudiantes
+administrate.instructors.view.results.note=Los profesores pueden ver los resultados
+administrate.instructors.email.students.note=Los profesores pueden enviar correos electr\u00F3nicos a los estudiantes
 administrate.instructors.hierarchy.note=Los Profesores pueden usar evaluaciones de arriba en la jerarquia
 administrate.instructors.num.questions.note=Los Profesores pueden a\u00F1adir este n\u00FAmero de preguntas a las evaluaciones desde arriba en la jerarqu\u00EDa ant\u00E9s de la fecha de publicaci\u00F3n
-administrate.student.settings.header=Ajustes Estudiantes:
-administrate.students.unanswered.note=Los Estudiantes pueden dejar preguntas sin contestar
-administrate.students.modify.responses.note=Los Estudiantes pueden modificar sus respuestas hasta la fecha de vencimiento
-administrate.students.view.results.note=Los Estudiantes pueden ver los resultados
-administrate.admin.settings.header=Ajustes Administrador:
+administrate.student.settings.header=Ajustes estudiantes:
+administrate.students.unanswered.note=Los estudiantes pueden dejar preguntas sin contestar
+administrate.students.modify.responses.note=Los estudiantes pueden modificar sus respuestas hasta la fecha de vencimiento
+administrate.students.view.results.note=Los estudiantes pueden ver los resultados
+administrate.admin.settings.header=Ajustes administrador:
 administrate.admin.hierarchy.num.questions.note=Los Administradores por debajo del nivel de jerarquia del propietario puede a\u00F1adir este n\u00FAmero de preguntas a las evaluaci\u00F3n antes de la fecha de publicaci\u00F3n
-administrate.admin.view.instructor.added.results.note=Los Administradores pueden ver los resultados de las preguntas a\u00F1adidas por los profesores.
-administrate.admin.view.below.results.note=Los Administradores pueden ver los resultados de los elementos a\u00F1adidos por debajo de ellos en la jerarqu\u00EDa
-administrate.hierarchy.settings.header=Ajustes Jerarqu\u00EDa:
+administrate.admin.view.instructor.added.results.note=Los administradores pueden ver los resultados de las preguntas a\u00F1adidas por los profesores.
+administrate.admin.view.below.results.note=Los administradores pueden ver los resultados de los elementos a\u00F1adidos por debajo de ellos en la jerarqu\u00EDa
+administrate.hierarchy.settings.header=Ajustes jerarqu\u00EDa:
 administrate.hierarchy-display-node-headers-note=Mostrar la jerarqu\u00EDa en las cabeceras del nodo para tener una vista previa de la evaluaci\u00F3n
-administrate.general.show.hierarchy.information=Usar men\u00FAs Jer\u00E1rquicos, opciones, e informaci\u00F3n del sistema
-administrate.general.settings.header=Ajustes Generales:
-administrate.general.helpdesk.email.note=Direcci\u00F3n de correo electr\u00F3nico de Ayuda (Los mensajes de correo electr\u00F3nico parecer\u00E1n venir de esta direcci\u00F3n de correo electr\u00F3nico por defecto)
+administrate.general.show.hierarchy.information=Usar men\u00FAs jer\u00E1rquicos, opciones, e informaci\u00F3n del sistema
+administrate.general.settings.header=Ajustes generales:
+administrate.general.helpdesk.email.note=Direcci\u00F3n de correo electr\u00F3nico de ayuda (Los mensajes de correo electr\u00F3nico parecer\u00E1n venir de esta direcci\u00F3n de correo electr\u00F3nico por defecto)
 administrate.general.responses.before.view.note=N\u00FAmero de respuestas requeridas antes de poder ver los resultados
 administrate.general.na.allowed.note=No aplicable cuando se permita la creaci\u00F3n de preguntas
 administrate.general.max.questions.block.note=M\u00E1ximo n\u00FAmero de preguntas en un bloque de preguntas
@@ -140,64 +140,64 @@ administrate.general.same.view.date.note=Usar la misma fecha de visualizaci\u00F
 administrate.general.eval.mim.time.diff.between.dates=M\u00EDnima diferencia de tiempo (en horas) entre la fecha de comienzo y la fecha de vencimiento de una evaluaci\u00F3n
 administrate.general.expert.templates.note=Usar plantillas creadas por expertos
 administrate.general.expert.questions.note=Usar preguntas creadas por expertos
-administrate.institution.specific.settings.header=Ajustes Espec\u00EDficos de la Instituci\u00F3n:
+administrate.institution.specific.settings.header=Ajustes espec\u00EDficos de la instituci\u00F3n:
 administrate.general.item.sharing.note=Habilitar opci\u00F3n de bandera para elementos espec\u00EDficos en evaluaciones de exporaci\u00F3n y compartici\u00F3n de bases de datos (UMD)
 administrate.general.enable.importing.note=Habilitar importaci\u00F3n de opciones y controles (UM)
 administrate.general.disable.item.bank=Deshabilitar el elemento banco
-administrate.general.disable.question.blocks=Deshabilitar los Bloques de Preguntas
-administrate.save.settings.button=Guardar Cambios
-administrate.top.import.data=Importar Datos
-administrate.top.control.hierarchy=Control Jerarqu\u00EDa
-administrate.top.control.reporting=Control Informe
+administrate.general.disable.question.blocks=Deshabilitar los bloques de preguntas
+administrate.save.settings.button=Guardar cambios
+administrate.top.import.data=Importar datos
+administrate.top.control.hierarchy=Control jerarqu\u00EDa
+administrate.top.control.reporting=Control informe
 administrate.general.require.comments.block.note=Requiere la inclusi\u00F3 de un bloque de comentarios en cada evaluaci\u00F3n
 administrate.general.eval.closed.still.recent.note=N\u00FAmero de d\u00EDas que puede una evaluaci\u00F3n permanecer como recientemente cerrada.
 administrate.sharing.owner=Propietario - Visibilidad establecida por el propietario
 administrate.true.label=S\u00ED
 administrate.false.label=No
 administrate.email.delivery=Control de los ajuste de correo electr\u00F3nico este establecido actualmente como {0} - que es apropiado para {1}
-administrate.general.enable.ta.category=Habilitar la categor\u00EDa de Profesor Asistente
+administrate.general.enable.ta.category=Habilitar la categor\u00EDa de profesor asistente
 administrate.use.admin.from.email=Usar la direcci\u00F3n de correo electr\u00F3nico del administrador de la evaluaci\u00F3n para enviar desde ellla las notificaciones (usar la direcci\u00F3n de la ayuda del sistema en caso contrario) (CAM)
 administrate.email.time.wait.secs=El tiempo en segundos entre la creaci\u00F3n de una evaluaci\u00F3n y el env\u00EDo de la notificaci\u00F3n de disponibilidad, por defecto 300 (5 min.)
 
 # Control Templates
-controltemplates.page.title=Mis Plantillas
-controltemplates.create.template.link=Nueva Plantilla
+controltemplates.page.title=Mis plantillas
+controltemplates.create.template.link=Nueva plantilla
 controltemplates.templates.header=Plantillas de Evaluaci\u00F3n
 controltemplates.templates.description=Elementos guardados de plantillas usados en un dise\u00F1o conceptual para crear evaluaciones
 controltemplates.templates.none=No hay plantillas disponibles
-controltemplates.template.title.header=T\u00EDtulo de Plantilla
+controltemplates.template.title.header=T\u00EDtulo de plantilla
 controltemplates.template.owner.header=Propietario
-controltemplates.template.lastupdate.header=\u00DAltima Actualizaci\u00F3n
+controltemplates.template.lastupdate.header=\u00DAltima actualizaci\u00F3n
 controltemplates.template.inuse.note=La plantilla esta actualmente en uso en almenos una evaluaci\u00F3n
 controltemplates.copy.user.message=Su plantilla ha sido copiada
 controltemplates.remove.user.message=Su plantilla ({0}) ha sido eliminada
 controltemplates.chown.user.message=Su plantilla ({0}) ahora pertenece a {1}
-controltemplates.chown.permission.message=El usuario {1} no tiene permisos para ser propietario de esta plantilla
+controltemplates.chown.permission.message={1} no tiene permisos para tener esta plantilla
 
 # Create template view
-createtemplate.page.title=A\u00F1adir Plantilla
+createtemplate.page.title=A\u00F1adir plantilla
 
 # Edit Template Title/Desc view
-modifytemplatetitledesc.page.title=Editar Plantilla T\u00EDtulo/Desc.
+modifytemplatetitledesc.page.title=Editar plantilla t\u00EDtulo/descrupci\u00F3n.
 modifytemplatetitledesc.description.header=Descripci\u00F3n
-modifytemplatetitledesc.description.note=Para usted y otros administradores. Cree notas o comentarios sobre esta Plantilla aqui.
-modifytemplatetitledesc.sharing.note=Nivel de compartici\u00F3n
-modifytemplatetitledesc.continue.button=Continuar y A\u00F1adir Preguntas
+modifytemplatetitledesc.description.note=Para usted y otros administradores. Cree notas o comentarios sobre esta plantilla aqu\u00ED.
+modifytemplatetitledesc.sharing.note=Nivel de compartir
+modifytemplatetitledesc.continue.button=Continuar y a\u00F1adir preguntas
 modifytemplatetitledesc.title.header=T\u00EDtulo 
 modifytemplatetitledesc.save.button=Guardar
 modifytemplatetitledesc.success.user.message=Actualizado t\u00EDtulo de plantilla y descripci\u00F3n
 
 # Remove Template view
-removetemplate.page.title=Borrar Plantilla
-removetemplate.noremove.text=Esta Plantilla ({0}) no puede ser borrada porque est\u00E1 actualmente en uso.
+removetemplate.page.title=Borrar plantilla
+removetemplate.noremove.text=Esta plantilla ({0}) no puede ser borrada porque est\u00E1 actualmente en uso.
 removetemplate.confirm.text=\u00BFEst\u00E1 seguro de querer borrar la plantilla "{0}"? El borrado es permanente.
-removetemplate.remove.button=Borrar Plantilla
+removetemplate.remove.button=Borrar plantilla
 
 # Chown Template view
-chowntemplate.page.title=Cambiar Propietario de la Plantilla
-chowntemplate.nochown.text=La plantilla ({0}) no puede ser cambiada porque est\u00E1 siendo utilizada en estos momentos
-chowntemplate.confirm.text=Est\u00E1 seguro de querer cambiar el propietario de la plantilla "{0}"? 
-chowntemplate.chown.label=Nuevo Propietario
+chowntemplate.page.title=Cambiar propiedad de la plantilla
+chowntemplate.nochown.text=La plantilla ({0}) no puede ser cambiada porque est\u00E1 siendo utilizada en estos momentos.
+chowntemplate.confirm.text=\u00BFSeguro que desea cambiar la persona propietaria de la plantilla "{0}"? 
+chowntemplate.chown.label=Nueva persona propietaria
 chowntemplate.chown.button=Guardar
 
 # eval general
@@ -208,7 +208,7 @@ evaluations.take.message=Respuesta guardada para evaluaci\u00F3n ({0}) de {1}
 controlevaluations.page.title=Mis Evaluaciones
 controlevaluations.partial.header=Evaluaciones Parcialmente Completas
 controlevaluations.partial.description=Sus Evaluations que ha empezado a crear pero no est\u00E1n completadas (\u00E9stas se eliminan autom\u00E1ticamente despu\u00E9s de un tiempo)
-controlevaluations.partial.created.date.header=Creada el
+controlevaluations.partial.created.date.header=Creada en fecha:
 controlevaluations.partial.continue=Continuar creando esta evaluaci\u00F3n
 controlevaluations.inqueue.header=Evaluaciones En-Cola
 controlevaluations.inqueue.description=Sus Evaluaciones en cola que a\u00FAn no han empezado todav\u00EDa
@@ -216,18 +216,18 @@ controlevaluations.inqueue.none=No hay evaluaciones en cola
 controlevaluations.active.header=Evaluaciones Activas
 controlevaluations.active.description=Sus Evaluaciones que est\u00E1n activas y pueden realizarse
 controlevaluations.active.none=No hay evaluaciones activas
-controlevaluations.active.close.now=Cerrar Ahora
+controlevaluations.active.close.now=Cerrar ahora
 controlevaluations.closed.header=Evaluaciones Cerradas
 controlevaluations.closed.description=Sus Evaluaciones las cuales han sido completadas
 controlevaluations.closed.none=No hay evaluaciones cerradas
 controlevaluations.closed.reopen.now=Reabrir
 controlevaluations.eval.title.header=T\u00EDtulo de la Evaluaci\u00F3n
-controlevaluations.eval.assigned.header=Asignada
-controlevaluations.eval.startdate.header=Fecha Comienzo
-controlevaluations.eval.duedate.header=Fecha Vencimiento
+controlevaluations.eval.assigned.header=Asignada a
+controlevaluations.eval.startdate.header=Fecha comienzo
+controlevaluations.eval.duedate.header=Fecha vencimiento
 controlevaluations.eval.settings.header=Ajustes
 controlevaluations.eval.responses.header=Respuestas
-controlevaluations.eval.responserate.header=Ratio de Respuesta
+controlevaluations.eval.responserate.header=Ratio de respuesta
 controlevaluations.eval.responses.inline={0}
 controlevaluations.eval.report.header=Informe
 controlevaluations.eval.direct.link=Enlace permanente
@@ -258,12 +258,12 @@ starteval.header=A\u00F1adir una Evaluaci\u00F3n nueva
 starteval.title.header=T\u00EDtulo
 starteval.instructions.header=Instrucciones
 starteval.instructions.desc=Aparecer\u00E1 en la parte superior de la evaluaci\u00F3n.
-starteval.choose.template.header=Elegir Plantilla
+starteval.choose.template.header=Elegir plantilla
 starteval.choose.template.desc=Seleccionar la plantilla a usar para esta evaluaci\u00F3n. Las plantillas definen las preguntas usadas.
-starteval.template.title.header=T\u00EDtulo de la Plantilla
+starteval.template.title.header=T\u00EDtulo de la plantilla
 starteval.template.ownder.header=Propietario
 starteval.view.preview.link=Previsualizar
-starteval.continue.settings.link=Continuar a Ajustes
+starteval.continue.settings.link=Continuar
 
 # Evaluation Settings view
 evalsettings.page.title=Ajustes de Evaluaci\u00F3n
@@ -271,39 +271,39 @@ evalsettings.title.settings=T\u00EDtulo de la Evaluaci\u00F3n:
 evalsettings.title.header=T\u00EDtulo
 evalsettings.instructions.header=Instrucciones
 evalsettings.instructions.desc=Aparecer\u00E1 en la parte superior de la evaluaci\u00F3n.
-evalsettings.choose.template.header=Elegir Plantilla
+evalsettings.choose.template.header=Elegir plantilla
 evalsettings.choose.template.desc=Seleccionar la plantilla a usar en esta evaluaci\u00F3n. Las plantillas definen las preguntas usadas.
-evalsettings.template.title.header=T\u00EDtulo de la Plantilla
+evalsettings.template.title.header=T\u00EDtulo de la plantilla
 evalsettings.template.owner.header=Propietario
 evalsettings.template.preview.link=Previsualizar
 evalsettings.template.title.display=Plantilla: {0}
 evalsettings.results.viewing.header=Resultados de la Evaluaci\u00F3n:
-evalsettings.results.viewing.sharing.header=Compartir Resultados:
+evalsettings.results.viewing.sharing.header=Compartir resultados: 
 evalsettings.results.sharing.note.private=Solo el propietario y los administradores pueden ver los resultados.
 evalsettings.results.sharing.note.visible=Los resultados son visibles según las opciones configuradas a continuación.
 evalsettings.results.sharing.note.public=Los resultados son públicos y accesibles para todos los usuarios asignados, independientemente de las opciones siguientes.
-evalsettings.results.viewable.admin.note=* N\u00F3tese que los administradores por encima en la jerarqu\u00EDa pueden ver los resultados A MENOS que los resultados compartidos se establezcan como privados
+evalsettings.results.viewable.admin.note=* Nota los administradores por encima en el jerarqu\u00EDa pueden ver los resultados A MENOS que los resultados compartidos se establezcan como privados
 evalsettings.studentViewResults.label=Los Participantes de los cursos a los que se les ha asignado esta evaluaci\u00F3n podr\u00E1n ver los resultados
 evalsettings.studentViewResults.disabled=Los resultados no podr\u00E1n ser vistos por los participantes de los cursos a los que ha sido asignada esta evaluaci\u00F3n.
 evalsettings.instructorViewResults.label=Los profesores de los cursos, a los que ha sido asignada, podr\u00E1n ver los resultados de esta evaluaci\u00F3n.
 evalsettings.instructorViewResults.disabled=Los resultados no podr\u00E1n ser vistos por los profesores de los cursos a los que ha sido asignada esta evaluaci\u00F3n.
 evalsettings.instructorViewAllResults.label=Los profesores pueden ver las respuestas a preguntas sobre otros profesores.
-evalsettings.instructorViewAllResults.disabled=Los profesores no pueden ver las respuestas a preguntas sobre otros profesores.
-evalsettings.view.results.date.label=Los resultados ser\u00E1n visibles despu\u00E9s de la fecha de vencimiento/visibilidad de la evaluaci\u00F3n
-evalsettings.view.results.students.date.after.label=Resultados visibles para estudiantes a partir de esta fecha
-evalsettings.view.results.instructors.date.after.label=Resultados visibles para profesores a partir de esta fecha
-evalsettings.blankResponsesAllowed.label=Se permite dejar en blanco preguntas no textuales.
-evalsettings.blankResponsesAllowed.disabled=Todas las preguntas no textuales deben ser respondidas
-evalsettings.blank.responses.allowed.note=Los Participantes no pueden enviar la evaluaci\u00F3n sin completar todos los elementos no textuales.
+evalsettings.instructorViewAllResults.disabled=Las personas evaluadas no pueden ver los informes de otras personas evaluadas.
+evalsettings.view.results.date.label=Los resultados ser\u00E1n visibles tras la fecha de entrega
+evalsettings.view.results.students.date.after.label=Resultados visibles para el alumnado despu\u00E9s de esta fecha
+evalsettings.view.results.instructors.date.after.label=Resultados visibles para el profesorado despu\u00E9s de esta fecha
+evalsettings.blankResponsesAllowed.label=Permitir dejar preguntas en blanco
+evalsettings.blankResponsesAllowed.disabled=Todas las preguntas deben ser respondidas (excepto las de tipo texto)
+evalsettings.blank.responses.allowed.note=Si no activa esta opci\u00F3n todas las preguntas ser\u00E1n obligatorias (excepto las de tipo texto, que siempre se pueden dejar en blanco)
 evalsettings.modifyResponsesAllowed.label=Se podr\u00E1n Modificar las respuestas mientras el periodo de evaluaci\u00F3n no est\u00E9 cerrado
 evalsettings.modifyResponsesAllowed.disabled=Las respuestas no pueden ser cambiadas despu\u00E9s de haber sido enviadas
 evalsettings.modify.responses.allowed.note=Los participantes pueden cambiar y reenviar sus respuestas si esto est\u00E1 habilitado
 evalsettings.admin.settings.instructions=Este ajuste permite dar al profesor control sobre el uso de la evaluaci\u00F3n (o simplemente se les solicita).
 evalsettings.reminder.settings.header=Notificaciones de la Evaluaci\u00F3n
-evalsettings.instructor.opt.desc=Ajuste de opciones de Profesor
-evalsettings.email.sent.from=Todos los correos electr\u00F3nicos se enviar\u00E1n desde {0} a menos que se modifique en el siguiente campo.
-evalsettings.available.mail.link=(\u00BFVer/Editar el correo electr\u00F3nico de notificaci\u00F3n?)
-evalsettings.student.completion.settings.header=Configuraci\u00F3n de Completado de Participante
+evalsettings.instructor.opt.desc=Ajuste de opciones de profesor
+evalsettings.email.sent.from=Todos los correos electr\u00F3nicos se enviar\u00E1n desde {0} a menos que se sobrescriban m\u00E1s abajo.
+evalsettings.available.mail.link=(Ver/Editar el correo electr\u00F3nico de notificaci\u00F3n)
+evalsettings.student.completion.settings.header=Configuraci\u00F3n de completado de participante
 evalsettings.emails.instructions=Por favor compruebe todo los detalles de la lista siguiente antes de guardar la configuraci\u00F3n de la encuesta.
 evalsettings.emails.appropriate=El mensaje por defecto est\u00E1 dise\u00F1ado para encuestas en las que se eval\u00FAan estudiantes de cursos y puede no ser apropiado para otro tipo de encuestas.
 evalsettings.available.mail.desc=Una notificaci\u00F3n de correo electr\u00F3nico ser\u00E1 enviada a todos los participantes asignados una evaluaci\u00F3n el d\u00EDa que esta comience. 
@@ -312,18 +312,18 @@ evalsettings.reminder.noresponders.header=Recordatorio de correo electr\u00F3nic
 # {0} is the date, {1} is the time
 evalsettings.dates.current=La fecha actual es {0}
 evalsettings.dates.header=Fechas de Evaluaci\u00F3n 
-evalsettings.start.date.header=Fecha Comienzo
+evalsettings.start.date.header=Fecha de comienzo
 evalsettings.start.date.desc=Los usuarios podr\u00E1n empezar a enviar las respuestas en esta fecha.
-evalsettings.due.date.header=Fecha de Vencimiente
+evalsettings.due.date.header=Fecha de vencimiento
 evalsettings.due.date.desc=La Evaluaci\u00F3n finalizar en esta fecha, no m\u00E1s respuestas despu\u00E9s de esta fecha.
-evalsettings.stop.date.header=Fecha L\u00EDmite
+evalsettings.stop.date.header=Fecha l\u00EDmite
 evalsettings.stop.date.desc=Los usuarios podr\u00E1n seguir enviando respuestas hasta esta fecha (define un periodo de gracia).
-evalsettings.view.date.header=Fecha Visualizaci\u00F3n
+evalsettings.view.date.header=Fecha visualizaci\u00F3n
 evalsettings.view.date.desc=Los resultados no son visibles hasta esta fecha.
-evalsettings.reminder.mail.link=(\u00BFVer/Editar el correo electr\u00F3nico recordatorio?)
-evalsettings.continue.assigning.link=Continuar a Asignar a Grupos
-evalsettings.reopening.eval.link=Reabrir y guardar configuraci\u00F3n 
-evalsettings.save.settings.link=Guardar Cambios
+evalsettings.reminder.mail.link=(Ver/Editar el correo electr\u00F3nico de recordatorio)
+evalsettings.continue.assigning.link=Continuar a asignar a sitios
+evalsettings.reopening.eval.link=Reabrir y guardar configuraci\u00F3n
+evalsettings.save.settings.link=Guardar cambios
 evalsettings.reminder.days.0=Nunca
 evalsettings.reminder.days.1=Diariamente
 evalsettings.reminder.days.2=Cada 2 d\u00EDas
@@ -333,21 +333,21 @@ evalsettings.reminder.days.5=Cada 5 d\u00EDas
 evalsettings.reminder.days.6=Cada 6 d\u00EDas
 evalsettings.reminder.days.7=Cada semana
 evalsettings.reminder.days.-1=24 horas antes que se cierre la encuesta
-evalsettings.admin.settings.header=Ajustes Administrativos
+evalsettings.admin.settings.header=Ajustes administrativos
 evalsettings.auth.control.instructions=Este ajuste le permite elegir si se requiere autenticaci\u00F3n para poder realizar esta evaluaci\u00F3n.
-evalsettings.auth.control.header=Control de Ajuste de Autenticaci\u00F3n
-evalsettings.auth.control.label.required=Requerida Autenticaci\u00F3n Central
-evalsettings.auth.control.label.key=Clave (Contrase\u00F1a requerida)
-evalsettings.auth.control.label.none=No (Permitir anonimos)
-evalsettings.instructors.label.opt.in=Los profesores tomar\u00E1n parte (Deshabilitada incialmente)
-evalsettings.instructors.label.opt.out=Los profesores no tomar\u00E1n parte (Habilitada incialmente)
-evalsettings.instructors.label.required=Los profesores podr\u00E1n hacer uso (Habilitada, no podr\u00E1n participar)
+evalsettings.auth.control.header=Control de ajuste de autenticaci\u00F3n
+evalsettings.auth.control.label.required=Requerida autenticaci\u00F3n central
+evalsettings.auth.control.label.key=Clave (contrase\u00F1a requerida)
+evalsettings.auth.control.label.none=No (permitir an\u00F3nimos)
+evalsettings.instructors.label.opt.in=El profesorado tomar\u00E1 parte (deshabilitada inicialmente)
+evalsettings.instructors.label.opt.out=El profesorado no tomar\u00E1 parte (habilitada inicialmente)
+evalsettings.instructors.label.required=El profesorado podr\u00E1 hacer uso (habilitada, no podr\u00E1n participar)
 evalsettings.from.email.header=Correo electr\u00F3nico desde/responder a:
 evalsettings.extra.settings.header=Extras de Evaluaci\u00F3n
 evalsettings.extra.category.header=Categor\u00EDa
 evalsettings.extra.category.instructions=La categor\u00EDa de una evaluaci\u00F3n se usa para agrupar evaluaciones relacionadas y para ver por categor\u00EDas.
-evalsettings.extra.eval.term.id.header=ID Semestre
-evalsettings.extra.eval.term.id.instructions=El ID semestre se usa para tener informaci\u00F3n adicional para el uso externo.
+evalsettings.extra.eval.term.id.header=ID del semestre
+evalsettings.extra.eval.term.id.instructions=El ID de periodo se usa para contener informaci\u00F3n adicional para uso externo.
 evalsettings.invalid.eval.category=La categor\u00EDa de una evaluaci\u00F3n contiene caracteres inv\u00E1lidos. Caracteres v\u00E1lidos incluyen caracteres alfanum\u00E9ricos y cualquiera de los siguientes: ()+*.-_=,:;!~@%
 evalsettings.updated.message=La configuraci\u00F3n de la evaluaci\u00F3n ({0}) ha sido actualizada
 evalsettings.invalid.dates=Las fechas para esta evaluaci\u00F3n no son v\u00E1lidas, Las fechas deben estar en orden de arriba a abajo
@@ -360,42 +360,42 @@ assigneval.assign.page.title=Editar Asignaci\u00F3n de Evaluaci\u00F3n para "{0}
 assigneval.assign.instructions=Puede asignar esta evaluaci\u00F3n ({0}) a los grupos siguientes
 assigneval.name.header=T\u00EDtulo
 assigneval.select.header=Seleccionar
-assigneval.edit.settings.button=Editar Ajustes
-assigneval.save.assigned.button=Guardar Grupos Asignados
+assigneval.edit.settings.button=Editar ajustes
+assigneval.save.assigned.button=Guardar grupos asignados
 assigneval.page.hier.title=Asignar Evaluaci\u00F3n a Nodos jer\u00E1rquicos
-assigneval.invalid.selection=Debe elegir al menos un grupo o un nodo que contenga almenos un grupo
-assigneval.page.groups.title=Asignar a los Grupos de Evaluaci\u00F3n
-assigneval.page.adhocgroups.title=Asignar a un Grupo adhoc
-assigneval.page.adhocgroups.newgrouplink=Crear un nuevo grupo Adhoc ahora
+assigneval.invalid.selection=Debe elegir al menos un grupo o un nodo que contenga al menos un grupo
+assigneval.page.groups.title=Asignar a los sitios de MiAulario
+assigneval.page.adhocgroups.title=Asignar a un grupo adhoc
+assigneval.page.adhocgroups.newgrouplink=Crear un nuevo grupo adhoc ahora
 assigneval.page.adhocgroups.editgrouplink=editar
 
 # Assign Confirm view
-evaluationassignconfirm.page.title=Confirmar Asignaci\u00F3n
+evaluationassignconfirm.page.title=Confirmar asignaci\u00F3n
 evaluationassignconfirm.eval.assign.info=Ha elegido asignar la evaluaci\u00F3n ({0}) a los grupos mostrados a continuaci\u00F3n.
 evaluationassignconfirm.eval.assign.instructions=Puede ajustar los grupos asignados a esta evaluaci\u00F3n  hasta la fecha de comienzo de la evaluaci\u00F3n ({0}).
-evaluationassignconfirm.courses.selected.header=Grupos Individuales Seleccionados:
-evaluationassignconfirm.no.groups.selected=No hay grupos seleccionados
-evaluationassignconfirm.hiernodes.selected.header=Nodos Jer\u00E1rquicos Seleccionados:
+evaluationassignconfirm.courses.selected.header=Sitios seleccionados:
+evaluationassignconfirm.no.groups.selected=No hay sitios seleccionados
+evaluationassignconfirm.hiernodes.selected.header=Nodos jer\u00E1rquicos seleccionados:
 evaluationassignconfirm.members=miembros
 evaluationassignconfirm.no.nodes.selected=No hay nodos jer\u00E1rquicos seleccionados
-evaluationassignconfirm.adhoc.selected.header=Grupos Individuales Seleccionados:
+evaluationassignconfirm.adhoc.selected.header=Grupos adhoc seleccionados:
 evaluationassignconfirm.no.adhoc.selected=No hay grupos adhoc seleccionados
 evaluationassignconfirm.direct.link=Enlace directo
 evaluationassignconfirm.done.button=Hecho
-evaluationassignconfirm.changes.assigned.courses.button=Cambiar Grupos Asignados
+evaluationassignconfirm.changes.assigned.courses.button=Cambiar sitios/grupos asignados
 
 # Display assignments view
 evaluationassignments.page.title=Mostrar Asignaciones de la Evaluaci\u00F3n
 evaluationassignments.info=Esto muestra los grupos y nodos jer\u00E1rquicos actuales a los que se le ha sido asignada la evaluaci\u00F3n.
 evaluationassignments.add.assigns.link=Modificar grupos asignados para esta evaluaci\u00F3n
-evaluationassignments.groups.header=Grupos Individuales
+evaluationassignments.groups.header=Sitios
 evaluationassignments.groups.name.header=Nombre
 evaluationassignments.groups.members.header=Miembros
-evaluationassignments.groups.type.header=Tipo de Grupo
+evaluationassignments.groups.type.header=Tipo de grupo
 evaluationassignments.no.groups=No hay grupos que mostrar
-evaluationassignments.nodes.header=Nodos Jer\u00E1rquicos
+evaluationassignments.nodes.header=Nodos jer\u00E1rquicos
 evaluationassignments.no.nodes=No hay nodos jer\u00E1rquicos que mostrar
-evaluationassignments.nodes.nodetitle.header=T\u00Edtulo de Nodo
+evaluationassignments.nodes.nodetitle.header=T\u00EDtulo de nodo
 evaluationassignments.nodes.abbr.header=Abreviaci\u00F3n
 
 #Remove Evaluation view
@@ -403,87 +403,87 @@ removeeval.page.title=Borrar Evaluaci\u00F3n
 removeeval.confirm.name=\u00BFEst\u00E1 seguro de querer borrar la evaluaci\u00F3n "{0}"? El borrado es permanente.
 removeeval.note=Toda la informaci\u00F3n relacionada con la evaluaci\u00F3n ser\u00E1 borrada de forma permanente.
 removeeval.title.header=T\u00EDtulo Evaluaci\u00F3n
-removeeval.assigned.header=Asignada
-removeeval.start.date.header=Fecha Comienzo
-removeeval.due.date.header=Fecha Vencimiento
+removeeval.assigned.header=Asignada a
+removeeval.start.date.header=Fecha comienzo
+removeeval.due.date.header=Fecha vencimiento
 removeeval.assigned.none=No
 removeeval.remove.button=Borrar Evaluaci\u00F3n
 
 # Preview Evaluation view
 previeweval.page.title=Previsualizando
-previeweval.template.title=Previsualizar Plantilla
+previeweval.template.title=Previsualizar plantilla
 previeweval.evaluation.title=Previsualizar Evaluaci\u00F3n
 previeweval.evaluation.title.prefix=Previsualizar Evaluaci\u00F3n:  
 previeweval.evaluation.title.header=Evaluaci\u00F3n:
 previeweval.course.title.header=Grupo:
 previeweval.instructions.title.header=Instrucciones:
 previeweval.evaluation.title.default=T\u00EDtulo Evaluaci\u00F3n Aqu\u00ED
-previeweval.course.title.default=T\u00EDtulo Grupo Aqu\u00ED
+previeweval.course.title.default=T\u00EDtulo sitio/grupo
 previeweval.instructions.default=Instrucciones de Evaluaci\u00F3n: deber\u00EDan ir aqu\u00ED si alguien las ha especificado. Este bloque puede ser de hasta 4000 caracteres.
-previeweval.course.questions.header=Elmentos Grupo/Curso:
-previeweval.instructor.questions.header=Elementos Evaluador/Profesor:
+previeweval.course.questions.header=Elementos de cat. "General":
+previeweval.instructor.questions.header=Elementos de cat. "Evaluaci\u00F3n a docente":
 
 
 # Control items
-controlitems.page.title=Mis Elementos
+controlitems.page.title=Mis elementos
 controlitems.items.header=Elementos
 controlitems.items.description=Preguntas o cuestiones a las que el evaluador responde.
-controlitems.items.add=A\u00F1adir Elemento
-controlitems.items.add.button=A\u00F1adir Elemento
+controlitems.items.add=A\u00F1adir elemento
+controlitems.items.add.button=A\u00F1adir elemento
 controlitems.expert.label=Experto
 controlitems.items.none=No hay elementos disponibles
 controlitems.items.metadata.title=Detalles de elemento
 controlitems.items.action.title=Acciones
-controlitems.items.owner.title=Propiertario
+controlitems.items.owner.title=Propietario
 controlitems.items.expert.title=Experto
 controlitems.copy.user.message=Elemento copiado ({0}) a un nuevo elemento ({1})
 
 
 # Add/Edit Items
-modifyitem.page.title=A\u00F1adir/Editar Elemento
+modifyitem.page.title=A\u00F1adir/Editar elemento
 modifyitem.item.header=Elemento:
 modifyitem.item.added.by.owner=A\u00F1adido por {0}
-modifyitem.added.by=a\u00F1adido por
-modifyitem.question.text.header=Pregunta de Texto :
-modifyitem.item.text.header=Elemento Texto
+modifyitem.added.by=A\u00F1adido por
+modifyitem.question.text.header=Pregunta de texto :
+modifyitem.item.text.header=Elemento a a\u00F1adir
 modifyitem.item.text.instruction=(Esta es la pregunta o cuesti\u00F3n a las que el evaluador te responder\u00E1)
 modifyitem.item.scale.header=Escala:
-modifyitem.item.choices.header=Introducir Opciones:
-modifyitem.scale.display.header=Mostrar Ajustes de Escala:
-modifyitem.choices.display.header=Mostrar Opciones de ajuste de visualizaci\u00F3n:
+modifyitem.item.choices.header=Introducir opciones de respuesta:
+modifyitem.scale.display.header=Elegir apariencia gr\u00E1fica:
+modifyitem.choices.display.header=Mostrar opciones de ajuste de visualizaci\u00F3n:
 modifyitem.item.sharing.header=Compartir:
-modifyitem.item.expert.header=Elemento Experto
+modifyitem.item.expert.header=Elemento experto
 modifyitem.item.expert.instruction=(indica que este elemento ha sido creado por un experto)
-modifyitem.item.expert.desc.header=Descripci\u00F3n de Experto
+modifyitem.item.expert.desc.header=Descripci\u00F3n de experto
 modifyitem.item.expert.desc.instruction= (describe el uso apropiado de este elemento para crear plantillas)
-modifyitem.display.hint.header=Consejos de ajuste de visualizaci\u00F3n
-modifyitem.display.hint.instruction=Estos ajustes opcionales permiten al autor del elemento proporcionar trucos de como se puede mostrar este elemento.
-modifyitem.display.header=Ajuste de Visualizaci\u00F3n
+modifyitem.display.hint.header=Configuraci\u00F3n
+modifyitem.display.hint.instruction=Estos ajustes opcionales ofrecen diferentes formas de presentaci\u00F3n para este elemento.
+modifyitem.display.header=Ajuste de visualizaci\u00F3n
 modifyitem.display.instruction=Estos ajustes permiten al autor del elemento controlar como se puede mostrar este elemento.
-modifyitem.item.response.size.header=Tama\u00F1o Respuesta:
+modifyitem.item.response.size.header=Tama\u00F1o respuesta:
 modifyitem.item.na.header=N/A (no aplicable)
 modifyitem.item.comment.header=Incluye cuadro de comentario
 modifyitem.item.compulsory.header=Obligatoria
 modifyitem.item.category.header=Categor\u00EDa:
-modifyitem.course.category=Grupo/Curso
-modifyitem.instructor.category=Evaluador/Profesor
+modifyitem.course.category=General
+modifyitem.instructor.category=Evaluaci\u00F3n a docente
 modifyitem.ta.category=Profesor Asistente
 modifyitem.environment.category=Entorno/Habitaci\u00F3n
 modifyitem.remove.link=Eliminar
 modifyitem.results.sharing.header=Compartir los resultados:
 modifyitem.hierarchy.assign.header=Asignaci\u00F3n de la jerarqu\u00EDa :
-modifyitem.preview.button=Previsualizar elemento
+modifyitem.preview.button=Previsualizaci\u00F3n del elemento
 modifyitem.save.button=Guardar elemento
 
 
 # Edit Template Items view
-modifytemplate.page.title=Editar Plantilla
+modifytemplate.page.title=Editar plantilla
 modifytemplateitems.page.title=Elementos de la plantilla
-modifytemplate.template.title.header=T\u00EDtulo Plantilla: 
-modifytemplate.add.item.note=A\u00F1adir Elemento:	
+modifytemplate.template.title.header=T\u00EDtulo plantilla: 
+modifytemplate.add.item.note=A\u00F1adir elemento:	
 modifytemplate.check.placeholder=x
 modifytemplate.check.label.title=Seleccionar para a\u00F1adir al bloque
-modifytemplate.preview.eval.link=Directo
+modifytemplate.preview.eval.link=Vista previa
 modifytemplate.preview.eval.link.title=Enlace Directo para previsualizar plantilla como una evaluaci\u00F3n
 modifytemplate.preview.eval.desc=\ de esta plantilla como una evaluaci\u00F3n
 modifytemplate.level.header= Nivel {0} - Elementos existentes {1} 
@@ -493,38 +493,38 @@ modifytemplate.begin.eval.link.title=Crear una nueva evaluaci\u00F3n usando esta
 modifytemplate.item.num.header=Elemento:
 modifytemplate.description.header=Descripci\u00F3n:
 modifytemplate.modify.title.desc.link=Editar
-modifytemplate.modify.title.desc.link.title=Editar Plantilla T\u00EDtulo/Descripci\u00F3n
+modifytemplate.modify.title.desc.link.title=Editar plantilla t\u00EDtulo/descripci\u00F3n
 modifytemplate.item.checkbox.title=Marcar elemento para usar en el bloque
-modifytemplate.item.category.title=Categor\u00EDa:
+modifytemplate.item.category.title=({0})
 modifytemplate.item.owner.title=Propiertario:
 modifytemplate.item.resultssharing.title=Compartir los resultados:
 modifytemplate.item.owner.title=Propietario:
-modifytemplate.item.scale.type.title=Tipo de Escala:
+modifytemplate.item.scale.type.title=Tipo de escala:
 modifytemplate.item.options=Opciones:
 modifytemplate.item.na.note=NA
 modifytemplate.item.comment.note=Comentario
-modifytemplate.item.hierarchy.level.title=Nivel Jer\u00E1rquico:
-modifytemplate.item.hierarchy.nodeid.title=ID Jerarqu\u00EDa:
-modifytemplate.itemtype.block=Bloque Preguntas
-modifytemplate.button.revert.order=Revertir Orden
+modifytemplate.item.hierarchy.level.title=Nivel jer\u00E1rquico:
+modifytemplate.item.hierarchy.nodeid.title=ID jerarqu\u00EDa:
+modifytemplate.itemtype.block=Bloque preguntas
+modifytemplate.button.revert.order=Revertir orden
 modifytemplate.button.revert.order.title=Revertir los elementos arrastrados y soltados atr\u00E1s a su orden original 
-modifytemplate.button.save.order=Guardar Orden
+modifytemplate.button.save.order=Guardar orden
 modifytemplate.button.save.order.title=Guardar el orden actual de los de los elementos despu\u00E9s de completar la acci\u00F3n de arrastrar y soltar. 
-modifytemplate.instructions.reorder=Arrastrar los elementos a reordenar y pulse guardar para establecer en nuevo orden o usar las flechas para reordenar un \u00FAnico elemento.
-modifytemplate.instructions.block=Validar las casilllas de verificaci\u00F3n para crear un conjunto de elementos despu\u00E9s hacer clic en Crear Bloque para crear un bloque con los elementos seleccionados
-modifytemplate.button.createblock=Crear Bloque
+modifytemplate.instructions.reorder=Arrastrar los elementos a reordenar y pulse guardar para establecer un nuevo orden o usar las flechas para reordenar un \u00FAnico elemento.
+modifytemplate.instructions.block=Validar las casillas de verificaci\u00F3n para crear un conjunto de elementos despu\u00E9s hacer clic en Crear Bloque para crear un bloque con los elementos seleccionados
+modifytemplate.button.createblock=Crear bloque
 modifytemplate.button.createblock.title=Crear un elemento de bloque usando los elementos que han sido seleccionados
-modifytemplate.group.cannot.delete.item=Lo sentimos, los grupos deben tener al menos DOS elementos.
+modifytemplate.group.cannot.delete.item=Lo sentimos, los grupos deben contener por lo menos DOS elementos.
 modifytemplate.group.ungroup=Desagrupar
 modifytemplate.select.order.title=Elegir un nuevo orden para este elemento
 
 # Template Item display
 templateitem.scale.select.compact=Compacto
-templateitem.scale.select.compactc=Coloreado Compacto
-templateitem.scale.select.full=Completo
-templateitem.scale.select.fullc=Coloreado Completo
+templateitem.scale.select.compactc=Coloreado compacto
+templateitem.scale.select.full=Horizontal
+templateitem.scale.select.fullc=Coloreado horizontal
 templateitem.scale.select.stepped=Escalonado
-templateitem.scale.select.steppedc=Coloreado Escalonado
+templateitem.scale.select.steppedc=Coloreado escalonado
 templateitem.scale.select.vertical=Vertical
 templateitem.response.select.size.2=2 l\u00EDneas
 templateitem.response.select.size.3=3 l\u00EDneas
@@ -535,27 +535,27 @@ templateitem.saved.message=Elemento {0} guardado en plantilla
 templateitem.removed.message=Elemento eliminado de plantilla
 
 # Expert Items Views
-expert.category.page.title=Elementos Expertos - Seleccione Categor\u00EDa
-expert.objective.page.title=Elementos Expertos - Seleccione Objetivo
+expert.category.page.title=Elementos expertos - Seleccione categor\u00EDa
+expert.objective.page.title=Elementos expertos - Seleccione objetivo
 expert.objective.summary= La columna 1 contiene enlaces usados para seleccionar objetivos, la columna 2 contiene informaci\u00F3n sobre estos objetivos
-expert.items.page.title=Elementos Expertos - Seleccione Elementos
+expert.items.page.title=Elementos expertos - Seleccione elementos
 expert.items.summary=La columna 1 contiene casillas de verificaci\u00F3n usadas para seleccionar elementos, la columna 2 contiene informaci\u00F3n sobre estos elementos
-expert.expert.items= Elementos Expertos
-expert.choose.category=(1) Seleccione Categor\u00EDa
-expert.choose.objective=(2) Seleccione Objetivo
-expert.choose.items=(3) Seleccione Elementos
+expert.expert.items=Elementos expertos
+expert.choose.category=(1) Seleccione categor\u00EDa
+expert.choose.objective=(2) Seleccione objetivo
+expert.choose.items=(3) Seleccione elementos
 expert.description=Descripci\u00F3n
-expert.no.description=No hay Descripci\u00F3n Disponible
+expert.no.description=No hay descripci\u00F3n disponible
 expert.category=Categor\u00EDa
-expert.category.list.summary=La columna 1 contiene enlaces a las categor\u00EDas, la column 2 contiene las descripciones de las categor\u00EDas
-expert.category.instructions=Haga Clic sobre una categor\u00EDa para ver los objetivos de la misma
+expert.category.list.summary=La columna 1 contiene enlaces a las categor\u00EDas, la columna 2 contiene las descripciones de las categor\u00EDas
+expert.category.instructions=Haga clic sobre una categor\u00EDa para ver los objetivos de la misma
 expert.objective=Objetivo
-expert.objective.instructions=Haga clil en un objetivo para seleccionar los elementos relacionados con el
+expert.objective.instructions=Haga clic en un objetivo para seleccionar los elementos relacionados con el
 expert.objective.or=O
 expert.items=Elementos Expertos
 expert.items.instructions=Selecciones los elementos que quiere usar en su plantilla y despu\u00E9s haga clic en el bot\u00F3n Insertar de la parte inferior
 expert.items.cancel=Cancelar
-expert.items.insert=Insertar Elementos
+expert.items.insert=Insertar elementos
 
 # Items views
 items.page.title=Elementos
@@ -564,8 +564,8 @@ items.choose.items=Seleccione elementos
 items.cancel=Cancelar
 items.search.command=Buscar
 items.select.col.title=Seleccionar
-items.item.col.title=Elementos Seleccionables
-item.list.summary=Elementos Seleccionables. La columna 1 contiene casillas de verificaci\u00F3n usadas para seleccionar los elementos, la columna 2 contiene informaci\u00F3n sobre estos elementos
+items.item.col.title=Elementos seleccionables
+item.list.summary=Elementos seleccionables. La columna 1 contiene casillas de verificaci\u00F3n usadas para seleccionar los elementos, la columna 2 contiene informaci\u00F3n sobre estos elementos
 
 # Remove Item/Template Item View
 removeitem.page.title=Eliminar elemento
@@ -573,7 +573,7 @@ removeitem.templateitem.confirmation=\u00BF Est\u00E1 seguro de querer eliminar 
 removeitem.item.confirmation=\u00BF Est\u00E1 seguro de querer eliminar el elemento mostrado a continuaci\u00F3n? El borrado es permanente.
 removeitem.block.text=Los bloques hijo ser\u00E1n repartidos y emplazados dentro de la plantilla en la misma ubicaci\u00F3n que ocupa en el bloque y en el mismo orden
 removeitem.remove.item.button=Eliminar elemento
-removeitem.inuse.warning=Advertencia: este elemento esta actualmente en uso en {0} plantillas, su eliminaci\u00F3n causar\u00EDa que se dejara de mostrar en estas plantillas
+removeitem.inuse.warning=Advertencia: este elemento est\u00E1 actualmente en uso en {0} plantillas, su eliminaci\u00F3n causar\u00EDa que se dejar\u00E1 de mostrar en estas plantillas.
 # 0=Template.id, 1=Template owner, 2=Template title
 removeitem.inuse.info=Plantilla ({0}): propietario={1}: {2}
 # 0=item.id
@@ -584,17 +584,17 @@ unblockitem.page.title=Desagrupar elemento
 unblockitem.confirmation=¿Seguro que quieres quitar este elemento del bloque? Pasará a ser un elemento independiente de la plantilla.
 
 # Preview Item view
-previewitem.page.title=Previsualizar Elemento
+previewitem.page.title=Previsualizar elemento
 
 # Edit Block View
-modifyblock.page.title=Editar Bloque
+modifyblock.page.title=Editar bloque
 modifyblock.page.instructions=Arrastrar y soltar para cambiar de lugar los elementos bloqueados.
 modifyblock.items.list.title=Bloquear elementos
 modifyblock.remove.link=Eliminar enlace
 modifyblock.item.header=Elementos
 modifyblock.item.header.text.header=Elemento cabecera de texto
-modifyblock.scale.type.header=Tipo de Escala: 
-modifyblock.ideal.coloring.header=Usar Coloreado Ideal
+modifyblock.scale.type.header=Tipo de escala: 
+modifyblock.ideal.coloring.header=Usar coloreado ideal
 modifyblock.add.item.to.block.button=A\u00F1adir elemento al bloque
 modifyblock.back.button=Atr\u00E1s
 modifyblock.error.scale.message=Los elementos seleccionados no tienen las mismas escalas
@@ -604,11 +604,11 @@ modifyblock.new.block.text=Introducir nuevo texto para el bloque
 
 
 # Control Scales view
-controlscales.page.title=Mis Escalas
+controlscales.page.title=Mis escalas
 controlscales.add.new.scale.link=A\u00F1adir una nueva escala
 controlscales.page.heading=Escalas
-controlscales.page.instruction= Lista de escalas disponibles. Las escalas que usted ha creado pueden ser editadas o eliminadas.
-controlscales.ideal.scale.title=Punto Ideal de la escala:
+controlscales.page.instruction=Lista de escalas disponibles. Tambi\u00E9n puede crear escalas nuevas personales, las cuales podr\u00E1 posteriormente editar o eliminar.
+controlscales.ideal.scale.title=Punto ideal de la escala:
 controlscales.ideal.scale.option.label.none=No
 controlscales.ideal.scale.option.label.mid=Centrado
 controlscales.ideal.scale.option.label.high=Abajo/Derecha
@@ -618,23 +618,23 @@ controlscales.copy.user.message=Copiar escala ({0}) a nueva escala ({1})
 
 
 # Scales Add Edit View
-modifyscale.page.title=A\u00F1adir/Editar Escala
-modifyscale.scale.title.note=T\u00EDtulo de la Escala
+modifyscale.page.title=A\u00F1adir/Editar escala
+modifyscale.scale.title.note=T\u00EDtulo de la escala
 modifyscale.adddropscale.note.start= A\u00F1adir/Eliminar elementos de escala
-modifyscale.remove.scale.link=Eliminar Escala
+modifyscale.remove.scale.link=Eliminar escala
 modifyscale.remove.scale.option.button=Eliminar
-modifyscale.add.scale.option.button=A\u00F1adir Punto de Escala
+modifyscale.add.scale.option.button=A\u00F1adir otra opci\u00F3n
 modifyscale.scale.ideal.note.start=Ideal
 modifyscale.scale.ideal.note.main.text=Indicar la posici\u00F3n de la "mejor" respuesta en esta escala (usada para gr\u00E1ficos y coloreado)
 modifyscale.scale.hidden.note=Esta escala no est\u00E1 visible en la interfaz (menus desplegables)
-modifyscale.save.scale.button=Guardar Escala
+modifyscale.save.scale.button=Guardar escala
 modifyscale.sharing.note=Compartir
 
 # Scale remove confirmation screen
-removescale.page.title=Eliminar Escala
-removescale.confirm.text=¿Esta seguro de querer eliminar la escala "{0}"? El borrado es permanente.
+removescale.page.title=Eliminar escala
+removescale.confirm.text=\u00BF Est\u00E1 seguro de querer eliminar la escala "{0}"? El borrado es permanente.
 removescale.remove.scale.button=Eliminar
-removescale.inuse.warning=Advertencia: Esta escala esta actualmente en uso en {0} elementos, eliminarla causar\u00E1 que queden ocultos
+removescale.inuse.warning=Advertencia: Esta escala est\u00E1 actualmente en uso en {0} elementos, eliminarla causar\u00E1 que queden ocultos
 # 0=item.id, 1=item type, 2=item owner, 3=item text
 removescale.inuse.info=Elemento ({0}): tipo={1}, propietario={2}: {3}
 # 0=scale.id
@@ -642,42 +642,42 @@ removescale.removed.user.message=La escala ({0}) ha sido eliminada
 
 
 # View Report view
-viewreport.page.title=Ver Informe
+viewreport.page.title=Ver informe
 viewreport.view.written=Ver s\u00F3lo respuestas escritas
 viewreport.view.all=Ver todos los elementos
 viewreport.view.csv=Exportar como CSV
 viewreport.view.xls=Exportar a Excel
 viewreport.view.pdf=Exportar a PDF
-viewreport.itemlist.course=Elementos de Curso/Grupo:
-viewreport.itemlist.instructor=Elementos de Profesor/Evaluador para {0}:
-viewreport.viewinggroups=Ver Grupos: {0}
+viewreport.itemlist.course=Elementos de sitio/grupo:
+viewreport.itemlist.instructor=Elementos de profesor/evaluador para {0}:
+viewreport.viewinggroups=Ver sitios/grupos: {0}
 viewreport.responses.count={0} respuestas
 viewreport.answers.percentage={0} ({1}%)
 viewreport.comments.header=Comentarios:
-viewreport.view.all.responses=Ver respuestas escritas
-viewreport.hide.all.responses=Ocultar respuestas escritas
+viewreport.view.all.responses=Ver todas las repuestas de texto
+viewreport.hide.all.responses=Ocultar todas las repuestas de texto
 viewreport.view.all.comments=Ver todos los comentarios
 viewreport.hide.all.comments=Ocultar todos los comentarios
-viewreport.no.responses=No hay Respuestas
-viewreport.no.comments=No hay Comentarios
+viewreport.no.responses=No hay respuestas
+viewreport.no.comments=No hay comentarios
 viewreport.not.allowed=No puede ver los resultados de esta evaluaci\u00F3n para ninguno de los grupos a los que ha sido asignada
 viewreport.answers.mean = {0} respuestas, media = {1}
 viewreport.weightedmean=Media ponderada
-viewreport.numberanswers=Numero de respuestas
-viewreport.numbercomments=Numero de comentarios
+viewreport.numberanswers=N\u00FAmero de respuestas
+viewreport.numbercomments=N\u00FAmero de comentarios
 viewreport.blockWeightedMean=Media ponderada del bloque
 viewreport.takers.csv.group.header=Grupo
 viewreport.takers.csv.username.header=Usuario
-viewreport.takers.csv.email.header=Dirección de correo
+viewreport.takers.csv.email.header=Direcci\u00F3n de email
 viewreport.takers.csv.name.header=Nombre
 viewreport.takers.csv.status.header=Estado
 
 #View Essay Responses view
-viewessay.page.title=Ver Respuestas de Ensayo
+viewessay.page.title=Ver respuestas de ensayo
 
 # Choose Report Groups view
-reportgroups.page.title=Seleccionar Informe Grupos
-reportgroups.main.message=Seleccione los grupos de los que desea ver los resultados. Los Resultados se mostrar\u00E1n conjuntamente.
+reportgroups.page.title=Seleccionar informe grupos
+reportgroups.main.message=Seleccione los grupos de los que desea ver los resultados. Los resultados se mostrar\u00E1n conjuntamente.
 
 # Reporting Strings
 reporting.pdf.defaultsystemname=Sistema de Evaluaci\u00F3n Online Sakai
@@ -692,21 +692,21 @@ reporting.xls.sheetname=Resultados
 reporting.spreadsheet.course=Curso/Grupo
 reporting.spreadsheet.instructor=Profesor/Evaluador: {0}
 reporting.notapplicable.shortlabel=N/A
-reporting.notapplicable.longlabel=No Aplicable
+reporting.notapplicable.longlabel=No aplicable
 
 # Control Email Templates
-controlemailtemplates.page.title=Mis Plantillas de Correo Electr\u00F3nico
-controlemailtemplates.show.defaults.link=Mostrar Plantillas por defecto
+controlemailtemplates.page.title=Mis plantillas de correo electr\u00F3nico
+controlemailtemplates.show.defaults.link=Mostrar plantillas por defecto
 controlemailtemplates.show.others.link=Mostrar otras plantillas
-controlemailtemplates.instructions=Este es un listado de las plantillas de correo electr\u00F3nico por defecto para el sistema, puede modificar estas plantillas, una vez las haya cambiado a la nueva versi\u00F3n ser\u00E1n usadas automaticamente para futuros correos electr\u00F3nicos
+controlemailtemplates.instructions=Este es un listado de las plantillas de correo electr\u00F3nico por defecto para el sistema, puede modificar estas plantillas, una vez las haya cambiado a la nueva versi\u00F3n ser\u00E1n usadas autom\u00E1ticamente para futuros correos electr\u00F3nicos
 controlemailtemplates.subject=Asunto: {0}
-controlemailtemplates.no.templates=No hay plantillas de correo electr\u00FAnico
-controlemailtemplates.template.saved.message=Guardada Plantilla de correo electr\u00F3nico {0}
-controlemailtemplates.template.removed.message=Eliminada la Plantilla de correo electr\u00F3nico ({0})
+controlemailtemplates.no.templates=No hay plantillas de correo electr\u00F3nico
+controlemailtemplates.template.saved.message=Guardada plantilla de correo electr\u00F3nico {0}
+controlemailtemplates.template.removed.message=Eliminada la plantilla de correo electr\u00F3nico ({0})
 controlemailtemplates.template.assigned.message=Plantilla {0} de correo electr\u00F3nico asignada ({1}) a la evaluaci\u00F3n ({2})
 
 # Edit Email view
-modifyemail.page.title=Editar Plantilla de Correo Electr\u00F3nico
+modifyemail.page.title=Editar plantilla de correo electr\u00F3nico
 # text: Edit Reminder email template
 modifyemail.modify.template.header=Editar plantilla de correo electr\u00F3nico {0}
 modifyemail.modify.text.instructions=Editar el texto sugerido para la plantilla de correo electr\u00F3nico. Por favor tenga en cuenta que al enviar el correo electr\u00F3nico los valores clave se sustituir\u00E1n con los valores reales. Usted puede usar estos valores en su plantilla de correo electr\u00F3nico.
@@ -735,14 +735,14 @@ ShowOptInText -  ser\u00E1 "true" si esta evaluaci\u00F3n es opt-in (exclusive w
 ShowOptOutText - ser\u00E1 "true" si esta evaluaci\u00F3n es opt-out (exclusive with opt-out) <br/>\
 
 modifyemail.template.subject=Asunto:
-modifyemail.save.changes.link=Guardar Cambios
+modifyemail.save.changes.link=Guardar cambios
 modifyemail.reset.to.default.link=Resetear a la plantilla por defecto
 
 # Preview Email view
-previewemail.page.title=Previsualizar Correo Electr\u00F3nico
+previewemail.page.title=Previsualizar correo electr\u00F3nico
 previewemail.header=Previsualizar el texto del correo electr\u00F3nico que ser\u00E1 enviado a los estudiantes
 previewemail.desc=Por favor dese cuenta que cuando est\u00E9 enviando el correo electr\u00F3nico los valores clave ser\u00E1n substituidos por los valores actuales
-previewemail.modify.button=Editar esta Plantilla de Correo Electr\u00F3nico
+previewemail.modify.button=Editar esta plantilla de correo electr\u00F3nico
 previewemail.back.button=Volver
 
 # Take Evaluation view
@@ -750,8 +750,8 @@ takeeval.page.title=Realizar Evaluaci\u00F3n
 takeeval.eval.title.header=Evaluaci\u00F3n:
 takeeval.group.title.header=Grupo:
 takeeval.instructions.header=Instrucciones:
-takeeval.group.questions.header=Elementos de Grupo/Curso: 
-takeeval.instructor.questions.header=Elementos Evaluador/Profesor: {0}
+takeeval.group.questions.header=Elementos de cat. General: 
+takeeval.instructor.questions.header=Elementos de Evaluaci\u00F3n a docente: {0}
 takeeval.submit.button=Enviar Evaluaci\u00F3n
 takeeval.user.cannot.take=No tiene permiso para realizar esta evaluaci\u00F3n ahora mismo
 takeeval.switch.group.header=Cambiar de grupo:
@@ -777,9 +777,9 @@ GeneralActionError=Ocurri\u00F3 un error inesperado al renderizar esta vista. Po
 admintesteg.page.title=Test EvalGroupProvider
 admintesteg.current.test.header=Actualmente
 admintesteg.current.test.user.header=Nombre de usuario
-admintesteg.current.test.group.header=Id Grupo
+admintesteg.current.test.group.header=Id grupo
 admintesteg.test.command=Test
-admintesteg.major.test.header=Resultados del Test
+admintesteg.major.test.header=Resultados del test
 admintesteg.test.method.header=M\u00E9todo
 admintesteg.test.result.header=Resultados
 admintesteg.test.result.skipped.nogroup=Saltar este test porque no se ha establecido el evalGroupId
@@ -789,19 +789,19 @@ admintesteg.test.runtime.message={0} milisegundos
 # Admin page for controlling reporting
 controlreporting.breadcrumb.title=Informe
 controlreporting.page.title=Control de informe
-controlreporting.exportformats.fieldtitle=Formatos de Exportaci\u00F3n Habilitados
+controlreporting.exportformats.fieldtitle=Formatos de exportaci\u00F3n habilitados
 controlreporting.pdfoptions.fieldtitle=Opciones PDF
 controlreporting.enable.csv.label=Habilitar Exportar CSV
 controlreporting.enable.xls.label=Habilitar Exportar XLS
 controlreporting.enable.pdf.label=Habilitar Exportar PDF
-controlreporting.enable.pdfbanner.label=Incluir Im\u00E1gen del Banner en el PDF
-controlreporting.pdfbanner.location.label=Ruta de Recursos de la imagen. (Aseg\u00FArese que la imagen es p\u00fablicable)
+controlreporting.enable.pdfbanner.label=Incluir Im\u00E1gen del banner en el PDF
+controlreporting.pdfbanner.location.label=Ruta de recursos de la imagen. (Aseg\u00FArese que la imagen es publicable)
 controlreporting.save=Guardar configuraci\u00F3n
 controlreporting.cancel=Cancelar
 
 # Admin page for controlling Hierarchy
 controlhierarchy.breadcrumb.title=Jerarqu\u00EDa
-controlhierarchy.page.title=Control de la Jerarqu\u00EDa
+controlhierarchy.page.title=Control de la jerarqu\u00EDa
 controlhierarchy.table.selectnode.header=Seleccionar
 controlhierarchy.table.heirarchy.header=Nivel Jer\u00e1rquico
 controlhierarchy.table.additem.header=A\u00F1adir Elemento
@@ -811,46 +811,44 @@ controlhierarchy.table.assigngroups.header=Asignar Grupos
 controlhierarchy.table.groupcount.header=N\u00FAm.Grupos
 controlhierarchy.add=A\u00F1adir
 controlhierarchy.modify=Modificar
-controlhierarchy.assigngroups=Asignar Grupos
+controlhierarchy.assigngroups=Asignar grupos
 controlhierarchy.remove=Eliminar
 controlhierarchy.done=Hecho
 
 # Admin page for Adding and Modifying Hierarchy Nodes
-modifyhierarchynode.breadcrumb.title=A\u00F1adir / Eliminar
+modifyhierarchynode.breadcrumb.title=A\u00F1adir / eliminar
 modifyhierarchynode.add.location=A\u00F1adiendo elemento bajo jerarqu\u00EDa "{0}"
 modifyhierarchynode.modify.location=Modificando nodo jer\u00E1rquico "{0}"
 modifyhierarchynode.title.label=T\u00EDtulo
 modifyhierarchynode.abbreviation.label=Abreviaci\u00F3n
-modifyhierarchynode.save=Guardar Elemento
+modifyhierarchynode.save=Guardar elemento
 modifyhierarchynode.cancel=Cancelar
 
 # Admin page for Assigning Groups to a Hierarchy Node
-hierarchynode.groups.breadcrumb.title=Asignar Grupos
-hierarchynode.groups.body.title=Assigning groups for Hierarchy Node "{0}"
+hierarchynode.groups.breadcrumb.title=Asignar grupos
+hierarchynode.groups.body.title=Asignaci\u00F3n de grupos al nodo de jerarqu\u00EDa "{0}"
 hierarchynode.groups.table.select=Seleccionar
 hierarchynode.groups.table.title=T\u00EDtulo
-hierarchynode.groups.save=Guardar Grupos Asignados
+hierarchynode.groups.save=Guardar grupos asignados
 hierarchynode.groups.cancel=Cancelar
 
 # Page for creating and modifying Adhoc Groups
-modifyadhocgroup.page.title.new=Creando un nuevo grupo Adhoc
-modifyadhocgroup.page.title.existing=Modificando el grupo Adhoc {0}
+modifyadhocgroup.page.title.new=Creando un nuevo grupo adhoc
+modifyadhocgroup.page.title.existing=Modificando el grupo adhoc {0}
 modifyadhocgroup.title.label=Nombre de grupo
-modifyadhocgroup.adhocuser.label=Usuario Adhoc
-modifyadhocgroup.newsave=Crear Grupo Adhoc 
-modifyadhocgroup.update=Actualizar Grupo Adhoc
+modifyadhocgroup.adhocuser.label=Usuario adhoc
+modifyadhocgroup.newsave=Crear grupo adhoc 
+modifyadhocgroup.update=Actualizar grupo adhoc
 modifyadhocgroup.backtoevalassign=Volver a Asignaciones de Evaluaciones a Grupo
 modifyadhocgroup.message.removeduser=Eliminar {0} del grupo.
 modifyadhocgroup.message.savednewgroup=Guardar grupo adhoc {0}
-modifyadhocgroup.message.badusers=No se pudo agregar usuarios {0}. Las entradas deben ser cuentas de \
-usuario v\u00E1lidas o direcciones de correo electr\u00F3nico.
-modifyadhocgroup.message.badusers.noadhocusers=No se pudo agregar usuarios {0}. Las entradas deben ser cuentas de \
-usuario v\u00E1lidas.
+modifyadhocgroup.message.badusers=Error al agregar las cuentas, {0}. Introduzca identificadores o direcciones de correo v\u00E1lido
+modifyadhocgroup.message.badusers.noadhocusers=Error al agregar las cuentas, {0}. Introduzca identificadores o direcciones de correo v\u00E1lidos.
 
-modifyadhocgroup.message.existingusers={0} ya existe en el grupo adhoc.
+modifyadhocgroup.message.existingusers={0} ya est\u00E1 en el grupo adhoc.
 modifyadhocgroup.message.duplicatetitle=Ya existe un grupo ad-hoc con ese nombre.
-modifyadhocgroup.message.emptygroup=No hay usuarios actualmente en este grupo.
-modifyadhocgroup.message.instructions=Introduzca un nombre de grupo y una lista de participantes. Los participantes deben ser listados uno por linea mediante IDs o direcciones de emails validos.
+modifyadhocgroup.message.emptygroup=No hay actualmente nadie en este grupo adhoc.
+modifyadhocgroup.message.instructions=Introduzca un nombre del grupo y una lista de participantes.
 modifyadhocgroup.message.pastetype=Pegue o escriba los correos electr\u00F3nicos de las personas que tienen que ser encuestadas a continuaci\u00F3n. Un nombre de usuario o correo electr\u00F3nico por l\u00EDnea.
 
 # P\u00E1gina de listado y gesti\u00F3n de Grupos Adhoc
@@ -868,4 +866,4 @@ controladhocgroups.deleted=Grupo ad-hoc eliminado correctamente.
 controladhocgroups.group.saved=Grupo ad-hoc "{0}" guardado.
 controladhocgroups.cannot.delete.locked=Este grupo no puede eliminarse porque est\u00E1 en uso en una encuesta activa o cerrada.
 
-permission.message=Establecer los permisos de Evaluaciones para el sitio
+permission.message=Establecer los permisos de Evaluaciones para el sitio 


### PR DESCRIPTION
## Summary
- Brings `messages_es_ES.properties` in line with a long-maintained institutional Spanish translation: spelling/accent corrections, capitalization consistency (sentence case instead of Title Case), and clearer wording in several labels/messages.
- Fixes two `{0}`/`{1}` MessageFormat placeholders that would otherwise have been lost/broken in the process (`evalsettings.dates.current`, `modifyadhocgroup.message.badusers*`).
- Terminology-only differences (local "Encuestas" branding vs "Evaluaciones") are intentionally left untouched — that's a private naming choice, not applicable upstream.

See EVALSYS-1613 for details/examples.

## Test plan
- [ ] Deploy with Spanish (España) locale selected and spot-check the changed labels/messages across item/scale/template management, reporting, evaluation settings, and the ad hoc group error messages.