### PR TITLE
EVALSYS-1614 Fixes from August 2026 preproduction tester feedback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>master</artifactId>
-        <version>26-SNAPSHOT</version>
+        <version>27-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/beans/EvalBeanUtils.java
+++ b/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/beans/EvalBeanUtils.java
@@ -99,9 +99,9 @@ public class EvalBeanUtils {
      */
     public boolean checkUserPermission(String userId, String ownerId) {
         boolean allowed = false;
-        if ( commonLogic.isUserAdmin(userId) ) {
+        if ( ownerId.equals(userId) ) {
             allowed = true;
-        } else if ( ownerId.equals(userId) ) {
+        } else if ( commonLogic.isUserAdmin(userId) ) {
             allowed = true;
         }
         return allowed;

--- a/sakai-evaluation-impl/pom.xml
+++ b/sakai-evaluation-impl/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.sakaiproject</groupId>
             <artifactId>sakai-coursemanagement-authz-provider-impl</artifactId>
-            <version>${project.version}</version>
+            <version>${sakai.version}</version>
         </dependency>
 
         <!-- Evaluation dependencies -->

--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImpl.java
@@ -606,8 +606,10 @@ public class EvalEvaluationSetupServiceImpl implements EvalEvaluationSetupServic
 
             if (removeTemplate) {
                 // remove template if it is a copy
-                if (EvalUtils.checkStateAfter(evaluation.getState(), EvalConstants.EVALUATION_STATE_PARTIAL, false)) {
-                    // this is not partial (partials do not have copies made yet)
+                if (EvalUtils.checkStateAfter(evaluation.getState(), EvalConstants.EVALUATION_STATE_PARTIAL, true)) {
+                    // saveEvaluation() copies the template on the very first save (isNew),
+                    // which happens while the eval is still Partial - so a copy can exist
+                    // even for a Partial eval, contrary to what this used to assume.
                     // remove the associated template if it is a copy (it should be)
                     EvalTemplate template;
                     if (evaluation.getTemplate() != null 

--- a/sakai-evaluation-impl/src/test/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImplTest.java
+++ b/sakai-evaluation-impl/src/test/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImplTest.java
@@ -352,13 +352,25 @@ public class EvalEvaluationSetupServiceImplTest extends BaseTestEvalLogic {
         evaluationSetupService.deleteEvaluation( EvalTestDataLoad.INVALID_LONG_ID, EvalTestDataLoad.MAINT_USER_ID);
 
         // http://jira.sakaiproject.org/jira/browse/EVALSYS-545 - removing partial eval will remove copied template as well
-        // test that removing an eval with a copied template does not remove the template if still partial
+        // Original 2008 fix made deleteEvaluation() skip the copied-template cleanup entirely while
+        // the eval is still Partial. That was broader than the actual EVALSYS-545 scenario required:
+        // saveEvaluation()'s isNew auto-copy logic already re-copies (into a *hidden* template) any
+        // template that is not itself hidden, so a user's own visible, deliberately-copied template
+        // (the real EVALSYS-545 concern) is never directly assigned to an evaluation and was never at
+        // risk from this cleanup in the first place. The 2008 test constructed a *hidden* template
+        // directly and asserted it survived - that is exactly the auto-generated, disposable copy
+        // that deleteEvaluation() should clean up, and was the source of orphaned copies for
+        // evaluations deleted while still Partial (confirmed against production data: 811 orphaned
+        // items out of 2669 copies). Split into two cases below: the hidden auto-copy case (must be
+        // cleaned up) and the real EVALSYS-545 case with a visible user-copied template (must survive).
+
+        // Hidden auto-copy directly assigned to a Partial eval: must be cleaned up on delete.
         Long templateId545 = authoringService.copyTemplate(etdl.templatePublic.getId(), "copy 545", EvalTestDataLoad.MAINT_USER_ID, true, false);
         EvalTemplate template545 = authoringService.getTemplateById(templateId545);
-        EvalEvaluation evalTest545 = new EvalEvaluation( EvalConstants.EVALUATION_TYPE_EVALUATION, 
-                EvalTestDataLoad.MAINT_USER_ID, "Eval valid title", 
-                etdl.today, etdl.tomorrow, etdl.threeDaysFuture, etdl.fourDaysFuture, 
-                EvalConstants.EVALUATION_STATE_PARTIAL, 
+        EvalEvaluation evalTest545 = new EvalEvaluation( EvalConstants.EVALUATION_TYPE_EVALUATION,
+                EvalTestDataLoad.MAINT_USER_ID, "Eval valid title",
+                etdl.today, etdl.tomorrow, etdl.threeDaysFuture, etdl.fourDaysFuture,
+                EvalConstants.EVALUATION_STATE_PARTIAL,
                 EvalConstants.SHARING_VISIBLE, 1, template545);
         evaluationSetupService.saveEvaluation( evalTest545, EvalTestDataLoad.MAINT_USER_ID, false ); // partial
         EvalEvaluation checkEval545 = evaluationService.getEvaluationById(evalTest545.getId());
@@ -369,7 +381,32 @@ public class EvalEvaluationSetupServiceImplTest extends BaseTestEvalLogic {
         evalIdToRemove = evalTest545.getId();
         evaluationSetupService.deleteEvaluation(evalIdToRemove, EvalTestDataLoad.ADMIN_USER_ID);
         Assert.assertNull( evaluationService.getEvaluationById(evalIdToRemove) );
-        Assert.assertNotNull( persistence.findById(EvalTemplate.class, checkEval545templateId) );
+        Assert.assertNull( persistence.findById(EvalTemplate.class, checkEval545templateId) );
+
+        // Real EVALSYS-545 case: a visible template the user deliberately copied for reuse. Assigning
+        // it to a new evaluation makes saveEvaluation() re-copy it into a separate hidden template, so
+        // the user's original visible template must never be touched by deleteEvaluation().
+        Long userTemplateId = authoringService.copyTemplate(etdl.templatePublic.getId(), "user's own copy", EvalTestDataLoad.MAINT_USER_ID, false, false);
+        EvalTemplate userTemplate = authoringService.getTemplateById(userTemplateId);
+        EvalEvaluation evalTestUserTemplate = new EvalEvaluation( EvalConstants.EVALUATION_TYPE_EVALUATION,
+                EvalTestDataLoad.MAINT_USER_ID, "Eval valid title",
+                etdl.today, etdl.tomorrow, etdl.threeDaysFuture, etdl.fourDaysFuture,
+                EvalConstants.EVALUATION_STATE_PARTIAL,
+                EvalConstants.SHARING_VISIBLE, 1, userTemplate);
+        evaluationSetupService.saveEvaluation( evalTestUserTemplate, EvalTestDataLoad.MAINT_USER_ID, false ); // partial
+        EvalEvaluation checkEvalUserTemplate = evaluationService.getEvaluationById(evalTestUserTemplate.getId());
+        Assert.assertNotNull(checkEvalUserTemplate);
+        Long assignedTemplateId = checkEvalUserTemplate.getTemplate().getId();
+        // confirms the auto-copy protection: the eval was NOT assigned the visible template directly
+        Assert.assertNotEquals(userTemplateId, assignedTemplateId);
+
+        evalIdToRemove = evalTestUserTemplate.getId();
+        evaluationSetupService.deleteEvaluation(evalIdToRemove, EvalTestDataLoad.ADMIN_USER_ID);
+        Assert.assertNull( evaluationService.getEvaluationById(evalIdToRemove) );
+        // the user's own visible template must survive
+        Assert.assertNotNull( persistence.findById(EvalTemplate.class, userTemplateId) );
+        // the disposable hidden auto-copy that was actually assigned must be cleaned up
+        Assert.assertNull( persistence.findById(EvalTemplate.class, assignedTemplateId) );
 
     }
 

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages.properties
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages.properties
@@ -304,6 +304,7 @@ controltemplates.template.owner.header=Owner
 controltemplates.template.lastupdate.header=Last Update
 controltemplates.template.inuse.note=Template is currently being used in at least one evaluation
 controltemplates.copy.user.message=Your template has been copied
+controltemplates.copy.confirm=Are you sure you want to copy this template?
 controltemplates.remove.user.message=Your template ({0}) has been removed
 controltemplates.chown.user.message=Your template ({0}) is now owned by {1}
 controltemplates.chown.nouser.message=No user was found matching the entered username or email.
@@ -655,7 +656,7 @@ controlitems.items.metadata.title=Item details
 controlitems.items.action.title=Actions
 controlitems.items.owner.title=Owner
 controlitems.items.expert.title=Expert
-controlitems.copy.user.message=Copied item ({0}) to new item ({1})
+controlitems.copy.user.message=Item copied successfully
 controlitems.items.classification.title=Classification
 
 # Control Expert Items
@@ -990,7 +991,7 @@ reporting.spreadsheet.instructor=Instructor/Evaluatee: {0}
 reporting.spreadsheet.ta=Teaching Assistant: {0}
 reporting.notapplicable.shortlabel=N/A
 reporting.notapplicable.longlabel=Not Applicable
-reporting.respondents.nologin=List not available: respondents did not have to log in
+reporting.respondents.nologin=List not available: respondents did not have to log in. Total responses: {0}
 
 # Control Email
 controlemail.title=Control Email Notifications

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages_es_ES.properties
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages_es_ES.properties
@@ -170,8 +170,10 @@ controltemplates.template.owner.header=Propietario
 controltemplates.template.lastupdate.header=\u00DAltima actualizaci\u00F3n
 controltemplates.template.inuse.note=La plantilla esta actualmente en uso en almenos una evaluaci\u00F3n
 controltemplates.copy.user.message=Su plantilla ha sido copiada
+controltemplates.copy.confirm=\u00BFEst\u00E1 seguro de que desea copiar esta plantilla?
 controltemplates.remove.user.message=Su plantilla ({0}) ha sido eliminada
 controltemplates.chown.user.message=Su plantilla ({0}) ahora pertenece a {1}
+controltemplates.chown.nouser.message=No se ha encontrado ning\u00FAn usuario que coincida con el nombre de usuario o correo electr\u00F3nico introducido.
 controltemplates.chown.permission.message={1} no tiene permisos para tener esta plantilla
 
 # Create template view
@@ -232,6 +234,7 @@ controlevaluations.eval.responses.inline={0}
 controlevaluations.eval.report.header=Informe
 controlevaluations.eval.direct.link=Enlace permanente
 controlevaluations.eval.groups.link={0} grupos
+controlevaluations.eval.group.deleted=Grupo eliminado
 controlevaluations.eval.report.link=Informe
 controlevaluations.eval.report.viewable.on=Visible el {0}
 controlevaluations.eval.report.awaiting.responses=Esperando {0} respuestas
@@ -239,6 +242,8 @@ controlevaluations.eval.preview.title=Previsualizar:
 controlevaluations.eval.link.title=Enlace R\u00E1pido:
 controlevaluations.create.user.message=Nueva evaluaci\u00F3n ({0}) ha sido creada y empezar\u00E1 el {1}
 controlevaluations.delete.user.message=Evaluaci\u00F3n ({0}) ha sido borrada
+controlevaluations.search.label=Buscar por t\u00EDtulo:
+controlevaluations.search.placeholder=Filtrar por t\u00EDtulo...
 controlevaluations.closed.user.message=Evaluaci\u00F3n ({0}) ha sido cerrada prematuramente
 controlevaluations.reopen.user.message=Evaluaci\u00F3n ({0}) ha sido reabierta
 
@@ -436,7 +441,7 @@ controlitems.items.metadata.title=Detalles de elemento
 controlitems.items.action.title=Acciones
 controlitems.items.owner.title=Propietario
 controlitems.items.expert.title=Experto
-controlitems.copy.user.message=Elemento copiado ({0}) a un nuevo elemento ({1})
+controlitems.copy.user.message=Elemento copiado correctamente
 
 
 # Add/Edit Items
@@ -563,6 +568,7 @@ items.existing.page.title=Seleccione elementos existentes
 items.choose.items=Seleccione elementos
 items.cancel=Cancelar
 items.search.command=Buscar
+existing.items=B\u00FAsqueda actual:
 items.select.col.title=Seleccionar
 items.item.col.title=Elementos seleccionables
 item.list.summary=Elementos seleccionables. La columna 1 contiene casillas de verificaci\u00F3n usadas para seleccionar los elementos, la columna 2 contiene informaci\u00F3n sobre estos elementos
@@ -619,6 +625,8 @@ controlscales.copy.user.message=Copiar escala ({0}) a nueva escala ({1})
 
 # Scales Add Edit View
 modifyscale.page.title=A\u00F1adir/Editar escala
+previewscale.page.title=Previsualizar escala
+previewscale.scale.response.type=Respuesta de la escala:
 modifyscale.scale.title.note=T\u00EDtulo de la escala
 modifyscale.adddropscale.note.start= A\u00F1adir/Eliminar elementos de escala
 modifyscale.remove.scale.link=Eliminar escala
@@ -693,6 +701,7 @@ reporting.spreadsheet.course=Curso/Grupo
 reporting.spreadsheet.instructor=Profesor/Evaluador: {0}
 reporting.notapplicable.shortlabel=N/A
 reporting.notapplicable.longlabel=No aplicable
+reporting.respondents.nologin=Listado no disponible: los encuestados no tuvieron que iniciar sesi\u00F3n. Respuestas totales: {0}
 
 # Control Email Templates
 controlemailtemplates.page.title=Mis plantillas de correo electr\u00F3nico
@@ -850,6 +859,7 @@ modifyadhocgroup.message.duplicatetitle=Ya existe un grupo ad-hoc con ese nombre
 modifyadhocgroup.message.emptygroup=No hay actualmente nadie en este grupo adhoc.
 modifyadhocgroup.message.instructions=Introduzca un nombre del grupo y una lista de participantes.
 modifyadhocgroup.message.pastetype=Pegue o escriba los correos electr\u00F3nicos de las personas que tienen que ser encuestadas a continuaci\u00F3n. Un nombre de usuario o correo electr\u00F3nico por l\u00EDnea.
+modifyadhocgroup.group.deleted=Grupo adhoc eliminado
 
 # P\u00E1gina de listado y gesti\u00F3n de Grupos Adhoc
 controladhocgroups.page.title=Mis Grupos Ad-hoc
@@ -866,4 +876,10 @@ controladhocgroups.deleted=Grupo ad-hoc eliminado correctamente.
 controladhocgroups.group.saved=Grupo ad-hoc "{0}" guardado.
 controladhocgroups.cannot.delete.locked=Este grupo no puede eliminarse porque est\u00E1 en uso en una encuesta activa o cerrada.
 
-permission.message=Establecer los permisos de Evaluaciones para el sitio 
+permission.message=Establecer los permisos de Evaluaciones para el sitio
+control.import.page.title=Importar datos XML
+control.import.instructions=Seleccione un archivo de datos XML para importar los datos de la evaluaci\u00F3n.
+control.import.upload.button=Subir e importar
+control.import.error.nofile=No se ha seleccionado ning\u00FAn archivo. Elija un archivo XML.
+control.import.error.exception=Se ha producido un error durante la importaci\u00F3n. Consulte los registros del servidor para m\u00E1s informaci\u00F3n.
+control.import.success.header=Importaci\u00F3n completada. Mensajes:

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ControlItemsController.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ControlItemsController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -113,9 +114,10 @@ public class ControlItemsController extends EvalControllerSupport {
     }
 
     @PostMapping("/copy")
-    public String copyItem(@RequestParam Long itemId) {
+    public String copyItem(@RequestParam Long itemId, RedirectAttributes redirectAttrs) {
         String currentUserId = currentUserId();
         authoringService.copyItems(new Long[]{itemId}, currentUserId, false, true);
+        redirectAttrs.addFlashAttribute("successMessage", "controlitems.copy.user.message");
         return "redirect:/control_items";
     }
 }

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/EvaluationAssignmentsController.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/EvaluationAssignmentsController.java
@@ -29,6 +29,7 @@ import org.sakaiproject.evaluation.constant.EvalConstants;
 import org.sakaiproject.evaluation.logic.EvalSettings;
 import org.sakaiproject.evaluation.logic.model.EvalGroup;
 import org.sakaiproject.evaluation.logic.model.EvalHierarchyNode;
+import org.sakaiproject.evaluation.model.EvalAdhocGroup;
 import org.sakaiproject.evaluation.model.EvalAssignGroup;
 import org.sakaiproject.evaluation.model.EvalAssignHierarchy;
 import org.sakaiproject.evaluation.model.EvalAssignUser;
@@ -68,11 +69,45 @@ public class EvaluationAssignmentsController extends EvalControllerSupport {
         private final List<GroupRow> groups;
     }
 
+    /**
+     * Direct link for a group row: for adhoc groups (managed entirely within evalsys,
+     * not backed by a real Sakai site group) this goes to their member editor - but only
+     * if the current user owns the adhoc group, since modify_adhoc_group rejects anyone
+     * else. Regular Sakai groups have no evalsys-side page to link to (their membership
+     * is managed in Site Info), so no link is offered for them.
+     */
+    private String buildDirectLink(HttpServletRequest request, String gid, String groupType,
+            String currentUserId, Long evaluationId, String backUrl) {
+        if (EvalConstants.GROUP_TYPE_ADHOC.equals(groupType) && gid.startsWith(EvalAdhocGroup.ADHOC_ID_PREFIX)) {
+            Long adhocGroupId = Long.valueOf(gid.substring(EvalAdhocGroup.ADHOC_ID_PREFIX.length()));
+            EvalAdhocGroup adhocGroup = commonLogic.getAdhocGroupById(adhocGroupId);
+            if (adhocGroup != null && currentUserId.equals(adhocGroup.getOwner())) {
+                // Carry our own backUrl along so that when the user lands back here (via
+                // Cancel/Save on modify_adhoc_group), the "Back" button below still points
+                // at the page evaluation_assignments was originally opened from, instead of
+                // at modify_adhoc_group itself (which is what plain history.go(-1) would do
+                // after this extra round trip).
+                String returnUrl = request.getContextPath() + "/evaluation_assignments?evaluationId=" + evaluationId
+                        + (backUrl != null ? "&backUrl=" + URLEncoder.encode(backUrl, StandardCharsets.UTF_8) : "");
+                return request.getContextPath() + "/modify_adhoc_group?adhocGroupId=" + adhocGroupId
+                        + "&returnUrl=" + URLEncoder.encode(returnUrl, StandardCharsets.UTF_8);
+            }
+        }
+        return null;
+    }
+
     @GetMapping
-    public String show(@RequestParam Long evaluationId, Model model, HttpServletRequest request) {
+    public String show(@RequestParam Long evaluationId,
+                       @RequestParam(required = false) String backUrl,
+                       Model model, HttpServletRequest request) {
         if (evaluationId == null)
             throw new IllegalArgumentException("evaluationId is required");
 
+        String currentUserId = currentUserId();
+        if (backUrl == null) {
+            backUrl = request.getHeader("Referer");
+        }
+        model.addAttribute("backUrl", backUrl);
         DateFormat df = DateFormat.getDateInstance(DateFormat.MEDIUM);
         EvalEvaluation eval = evaluationService.getEvaluationById(evaluationId);
         model.addAttribute("evaluationId", evaluationId);
@@ -122,8 +157,7 @@ public class EvaluationAssignmentsController extends EvalControllerSupport {
             boolean published = commonLogic.isEvalGroupPublished(gid);
             if (!published) unpublishedCount++;
 
-            String directLink = request.getContextPath() + "/preview_eval?evaluationId=" + evaluationId
-                    + "&evalGroupId=" + URLEncoder.encode(gid, StandardCharsets.UTF_8);
+            String directLink = buildDirectLink(request, gid, group.type, currentUserId, evaluationId, backUrl);
 
             int instructorCount = 0, assistantCount = 0;
             if (hasInstructors) {
@@ -164,8 +198,7 @@ public class EvaluationAssignmentsController extends EvalControllerSupport {
                     if (ah.getNodeId().equals(ag.getNodeId())) {
                         String gid = ag.getEvalGroupId();
                         EvalGroup g = commonLogic.makeEvalGroupObject(gid);
-                        String dl = request.getContextPath() + "/preview_eval?evaluationId=" + evaluationId
-                                + "&evalGroupId=" + URLEncoder.encode(gid, StandardCharsets.UTF_8);
+                        String dl = buildDirectLink(request, gid, g.type, currentUserId, evaluationId, backUrl);
                         nodeGroups.add(new GroupRow(g.title, g.type, dl,
                                 evaluatorCount.getOrDefault(gid, 0), 0, 0, true));
                     }

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/EvaluationSettingsController.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/EvaluationSettingsController.java
@@ -135,7 +135,7 @@ public class EvaluationSettingsController extends EvalControllerSupport {
         model.addAttribute("userAdmin",         userAdmin);
         model.addAttribute("currentDate",       dtf.format(new Date()));
 
-        addEditabilityModel(model, displayState.currentEvalState);
+        addEditabilityModel(model, displayState.currentEvalState, displayState.reOpening);
         addSystemSettingsModel(model, userAdmin);
         addSelectConstantsModel(model);
         addDateModel(model, eval, displayState);
@@ -162,7 +162,7 @@ public class EvaluationSettingsController extends EvalControllerSupport {
         if (reopen) {
             Boolean enableReOpen = (Boolean) settings.get(EvalSettings.ENABLE_EVAL_REOPEN);
             if (Boolean.TRUE.equals(enableReOpen) &&
-                    EvalUtils.checkStateAfter(state.currentEvalState, EvalConstants.EVALUATION_STATE_CLOSED, false)) {
+                    EvalUtils.checkStateAfter(state.currentEvalState, EvalConstants.EVALUATION_STATE_CLOSED, true)) {
                 state.currentEvalState = EvalConstants.EVALUATION_STATE_ACTIVE;
                 state.reOpening = true;
                 Calendar cal = Calendar.getInstance();
@@ -174,7 +174,7 @@ public class EvaluationSettingsController extends EvalControllerSupport {
         return state;
     }
 
-    private void addEditabilityModel(Model model, String currentEvalState) {
+    private void addEditabilityModel(Model model, String currentEvalState, boolean reOpening) {
         Boolean useStopDate = (Boolean) settings.get(EvalSettings.EVAL_USE_STOP_DATE);
         Boolean useViewDate = (Boolean) settings.get(EvalSettings.EVAL_USE_VIEW_DATE);
 
@@ -195,7 +195,7 @@ public class EvaluationSettingsController extends EvalControllerSupport {
         model.addAttribute("instrOptDisabled",
                 EvalUtils.checkStateAfter(currentEvalState, EvalConstants.EVALUATION_STATE_INQUEUE, true));
         model.addAttribute("reminderDisabled",
-                EvalUtils.checkStateAfter(currentEvalState, EvalConstants.EVALUATION_STATE_GRACEPERIOD, true));
+                !reOpening && EvalUtils.checkStateAfter(currentEvalState, EvalConstants.EVALUATION_STATE_GRACEPERIOD, true));
         model.addAttribute("respondentSettingsDisabled",
                 EvalUtils.checkStateAfter(currentEvalState, EvalConstants.EVALUATION_STATE_ACTIVE, true));
         model.addAttribute("viewSettingsDisabled",

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ModifyTemplateItemsController.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ModifyTemplateItemsController.java
@@ -17,6 +17,9 @@ package org.sakaiproject.evaluation.tool.controllers;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.sakaiproject.evaluation.constant.EvalConstants;
 import org.sakaiproject.evaluation.logic.EvalSettings;
 import org.sakaiproject.evaluation.logic.model.EvalHierarchyNode;
@@ -41,6 +44,45 @@ import lombok.Data;
 @RequestMapping("/modify_template_items")
 public class ModifyTemplateItemsController extends EvalControllerSupport {
 
+    private static final String BACK_URL_SESSION_KEY = "modifyTemplateItemsBackUrl";
+
+    // Item-editing sub-screens that redirect back here on their own (not real origins):
+    // their Referer must never overwrite the backUrl captured from the real entry point.
+    private static final String[] CHILD_SCREEN_PATHS = {
+        "/modify_item", "/remove_item", "/unblock_item", "/modify_block",
+        "/choose_existing_items", "/choose_expert_items",
+        "/choose_expert_objective", "/choose_expert_category",
+        // "/modify_template" also matches "/modify_template_items" itself (substring),
+        // covering both the template-info edit screen and self-referencing reloads
+        // (e.g. the partial item-row refresh, EVALSYS-878) - neither is a real origin.
+        "/modify_template"
+    };
+
+    /**
+     * Resolves where the "Back" button should go: the page modify_template_items was
+     * originally opened from (My Templates, or Evaluation Settings while building an
+     * eval), not the item sub-screen that just redirected back here. Stored in the
+     * session because each item add/edit/remove/unblock action is its own full-page
+     * redirect back to this URL, so browser history (history.go(-1)) would land on that
+     * sub-screen instead.
+     */
+    private String resolveBackUrl(HttpServletRequest request) {
+        HttpSession session = request.getSession();
+        String referer = request.getHeader("Referer");
+        boolean refererIsChildScreen = false;
+        if (referer != null) {
+            for (String childPath : CHILD_SCREEN_PATHS) {
+                if (referer.contains(childPath)) {
+                    refererIsChildScreen = true;
+                    break;
+                }
+            }
+        }
+        if (referer != null && !refererIsChildScreen) {
+            session.setAttribute(BACK_URL_SESSION_KEY, referer);
+        }
+        return (String) session.getAttribute(BACK_URL_SESSION_KEY);
+    }
 
     @Data
     public static class TemplateItemRow {
@@ -79,7 +121,9 @@ public class ModifyTemplateItemsController extends EvalControllerSupport {
     @GetMapping
     public String show(@RequestParam Long templateId,
                        @RequestParam(required = false) Long templateItemId,
-                       Model model) {
+                       Model model, HttpServletRequest request) {
+
+        model.addAttribute("backUrl", resolveBackUrl(request));
 
         String currentUserId = currentUserId();
         EvalTemplate template = localTemplateLogic.fetchTemplate(templateId);

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/CSVTakersReportExporter.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/reporting/CSVTakersReportExporter.java
@@ -76,9 +76,11 @@ public class CSVTakersReportExporter implements ReportExporter {
     }
 
     public void buildReport(EvalEvaluation evaluation, String[] groupIds, String evaluateeId, OutputStream outputStream, String exportType) {
+        List<EvalResponse> responses = deliveryService.getEvaluationResponses(evaluation.getId(), groupIds, null);
+
         if (EvalConstants.EVALUATION_AUTHCONTROL_NONE.equals(evaluation.getAuthControl())) {
             try (OutputStreamWriter osw = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
-                osw.write(messages.getMessage("reporting.respondents.nologin"));
+                osw.write(messages.getMessage("reporting.respondents.nologin", responses.size()));
             } catch (IOException e) {
                 throw new RuntimeException("IO Exception writing CSV takers", e);
             }
@@ -87,8 +89,7 @@ public class CSVTakersReportExporter implements ReportExporter {
 
         boolean multiGroup = groupIds != null && groupIds.length > 1;
 
-        // Load responses indexed by groupId → (userId → response)
-        List<EvalResponse> responses = deliveryService.getEvaluationResponses(evaluation.getId(), groupIds, null);
+        // Index responses by groupId → (userId → response)
         Map<String, Map<String, EvalResponse>> groupUserResponses = new HashMap<>();
         for (EvalResponse r : responses) {
             groupUserResponses.computeIfAbsent(r.getEvalGroupId(), k -> new HashMap<>())

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/templates/control_items.html
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/templates/control_items.html
@@ -44,6 +44,11 @@
         <li class="lastCrumbNoFloat" th:text="#{controlitems.page.title}">My Items</li>
     </ul>
 
+    <!-- Flash success message -->
+    <div th:if="${successMessage}" class="alertMessage successMessage">
+        <ul><li th:text="#{__${successMessage}__}">OK</li></ul>
+    </div>
+
     <!-- Link to expert items (if enabled) -->
     <p th:if="${useExpertItems}">
         <a th:href="@{/control_expert_items}"

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/templates/control_templates.html
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/templates/control_templates.html
@@ -90,7 +90,9 @@
                            class="left-separator"
                            th:text="#{general.command.preview}">Preview</a>
                         <!-- Copiar -->
-                        <form th:action="@{/control_templates/copy}" method="post" class="inlineForm left-separator">
+                        <form th:action="@{/control_templates/copy}" method="post" class="inlineForm left-separator"
+                              onsubmit="return confirm(this.dataset.confirm)"
+                              th:data-confirm="#{controltemplates.copy.confirm}">
                             <input type="hidden" name="templateId" th:value="${row.templateId}"/>
                             <input type="submit" th:value="#{general.copy}" class="makeLink"/>
                         </form>

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/templates/evaluation_assignments.html
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/templates/evaluation_assignments.html
@@ -76,10 +76,11 @@
         <tr th:each="row : ${groupRows}">
             <td width="60%">
                 <span th:text="${row.title}" th:classappend="${!row.published} ? 'elementAlertFront' : ''">Group title</span>
-                &nbsp;(<a th:href="${row.directLink}"
-                          th:text="#{evaluationassignconfirm.direct.link}"
-                          title="Direct URL to the evaluation for this group"
-                          target="_blank">link</a>)
+                <th:block th:if="${row.directLink != null}">
+                    &nbsp;(<a th:href="${row.directLink}"
+                              th:text="#{evaluationassignconfirm.direct.link}"
+                              title="Direct URL to manage this group's members">link</a>)
+                </th:block>
             </td>
             <td th:if="${hasInstructors}" width="10%" th:text="${row.enrollmentInstructors}">0</td>
             <td th:if="${hasAssistants}" width="10%" th:text="${row.enrollmentAssistants}">0</td>
@@ -125,9 +126,11 @@
                             <tr th:each="g : ${node.groups}">
                                 <td>
                                     <span th:text="${g.title}">Group title</span>
-                                    &nbsp;(<a th:href="${g.directLink}"
-                                              th:text="#{evaluationassignconfirm.direct.link}"
-                                              target="_blank">link</a>)
+                                    <th:block th:if="${g.directLink != null}">
+                                        &nbsp;(<a th:href="${g.directLink}"
+                                                  th:text="#{evaluationassignconfirm.direct.link}"
+                                                  title="Direct URL to manage this group's members">link</a>)
+                                    </th:block>
                                 </td>
                                 <td align="center" th:text="${g.enrollmentCount}">0</td>
                                 <td align="center" th:text="${g.type}">type</td>
@@ -142,7 +145,9 @@
     </th:block>
 
     <br/>
-    <input type="button" th:value="#{general.back.button}" accesskey="x"
+    <a th:if="${backUrl != null}" th:href="${backUrl}" accesskey="x"
+       onclick="SPNR.disableControlsAndSpin(this, null);" th:text="#{general.back.button}">Back</a>
+    <input th:unless="${backUrl != null}" type="button" th:value="#{general.back.button}" accesskey="x"
            onclick="SPNR.disableControlsAndSpin(this, null); history.go(-1);"/>
 
 </div>

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/templates/modify_template_items.html
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/templates/modify_template_items.html
@@ -348,6 +348,10 @@
                 <div class="cleaner">&nbsp;</div>
             </div>
 
+            <br/>
+            <a th:href="${backUrl != null} ? ${backUrl} : @{/control_templates}" accesskey="x"
+               onclick="SPNR.disableControlsAndSpin(this, null);" th:text="#{general.back.button}">Back</a>
+
         </div>
         <!-- end padding div -->
 

--- a/sakai-evaluation-tool/src/webapp/content/css/scss/_layout.scss
+++ b/sakai-evaluation-tool/src/webapp/content/css/scss/_layout.scss
@@ -7,6 +7,23 @@
 // Only layout related styles should be included here:
 // height, width, margin, padding, position, etc.
 
+/* ===== portletBody bottom margin =====
+   The Sakai skin's tool.css sets ".portletBody { margin-bottom: 3rem !important; }"
+   (this rule is present in both the Sakai 25 and Sakai/master skin sources) and tries
+   to cancel it for tools whose body's direct child is .portletBody via
+   "body > .portletBody { margin-bottom: 0; }" — but that override has no !important, so
+   it can never win against the rule above. The leftover 42px collapses through the
+   (border/padding-less) <body> into <html>, inflating its scrollHeight past its
+   clientHeight and producing a spurious inner scrollbar on short pages (e.g. the
+   dashboard/summary view when there are no evaluations to show). Every evalsys template
+   wraps its content in this exact element, so re-assert the intended override here with
+   matching specificity (two classes) and !important. Kept outside sakai25-compat.scss
+   on purpose: the bug also affects the Sakai/master skin, so this must not disappear
+   when that compat file is retired for Sakai 26. */
+.portletBody.evaluation,
+.Mrphs-sakai-rsf-evaluation {
+  margin-bottom: 0 !important;
+}
 
 /////////////////////////
 // Evaluation


### PR DESCRIPTION
## Summary
Batch of fixes from a round of preproduction tester feedback collected 2026-08-05, reviewed and fixed one by one.

- "My Items" took ~17s to load with many items: `EvalBeanUtils.checkUserPermission()` checked the uncached `isUserAdmin()` before the cheap `ownerId.equals(userId)` comparison, called twice per item in the list.
- Reopening a closed evaluation only allowed changing the due date, not reminder settings, title or instructions; reopen mode also only activated once the evaluation reached the Viewable state, not when exactly Closed. Both fixed.
- Double inner scrollbar on the evaluation summary/dashboard page on short pages, caused by the skin's `.portletBody { margin-bottom: 3rem !important; }` not being properly overridden.
- On the evaluation group assignments screen, "Direct link" next to an assigned group always pointed at the evaluation itself. Now links to the adhoc group's member editor instead (same window, working Back button); hidden for regular Sakai groups since there's no evalsys-side page to link to.
- CSV export of participants for an anonymous (no-login) evaluation now reports the total response count instead of just a static "not available" message.
- Template item editing screen ("Edit" from My Templates) had no way back, unlike every other action in that list; added a Back button. "Copy" template now asks for confirmation before copying.
- Copying an item in "My Items" now shows a success message instead of silently redirecting back to the list.

JIRA: EVALSYS-1614

## Test plan
See test plan on the JIRA ticket: https://sakaiproject.atlassian.net/browse/EVALSYS-1614