### PR TITLE
EVALSYS-1616 Improve My Email Templates screen and fix SUBMITTED-type gaps

### DIFF
--- a/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/dao/EvaluationEmailTemplateDao.java
+++ b/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/dao/EvaluationEmailTemplateDao.java
@@ -14,7 +14,9 @@
  */
 package org.sakaiproject.evaluation.dao;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.sakaiproject.evaluation.model.EvalEmailTemplate;
@@ -28,11 +30,28 @@ public interface EvaluationEmailTemplateDao {
 
     public List<EvalEmailTemplate> getEmailTemplates(String ownerUserId, String emailTemplateType, Boolean includeDefaultsOnly);
 
+    /**
+     * Same as {@link #getEmailTemplates(String, String, Boolean)} but paginated, ordered by most
+     * recently modified first.
+     */
+    public List<EvalEmailTemplate> getEmailTemplates(String ownerUserId, String emailTemplateType, Boolean includeDefaultsOnly,
+            int firstResult, int maxResults);
+
+    public int countEmailTemplates(String ownerUserId, String emailTemplateType, Boolean includeDefaultsOnly);
+
     public EvalEmailTemplate getDefaultEmailTemplate(String emailTemplateType);
 
     public EvalEmailTemplate getEmailTemplateByEid(String eid);
 
     public List<EvalEvaluation> getEvaluationsUsingEmailTemplate(Long emailTemplateId, String emailTemplateType);
+
+    /**
+     * Batch version of {@link #getEvaluationsUsingEmailTemplate(Long, String)}: resolves, in a single
+     * query, which evaluations use each of the given email template ids (all must be of the same type).
+     *
+     * @return a Map (emailTemplateId -&gt; evaluations using it); ids with no evaluations using them are absent
+     */
+    public Map<Long, List<EvalEvaluation>> getEvaluationsUsingEmailTemplates(Collection<Long> emailTemplateIds, String emailTemplateType);
 
     public int countEvaluationsUsingEmailTemplate(Long emailTemplateId, String emailTemplateType);
 

--- a/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationService.java
+++ b/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationService.java
@@ -613,6 +613,29 @@ public interface EvalEvaluationService {
      */
     public List<EvalEmailTemplate> getEmailTemplatesForUser(String userId, String emailTemplateTypeConstant, Boolean includeDefaultsOnly);
 
+    /**
+     * Same as {@link #getEmailTemplatesForUser(String, String, Boolean)} but paginated, ordered by most
+     * recently modified first.
+     */
+    public List<EvalEmailTemplate> getEmailTemplatesForUser(String userId, String emailTemplateTypeConstant, Boolean includeDefaultsOnly,
+            int firstResult, int maxResults);
+
+    /**
+     * @return the total count matching {@link #getEmailTemplatesForUser(String, String, Boolean, int, int)}, for pagination
+     */
+    public int countEmailTemplatesForUser(String userId, String emailTemplateTypeConstant, Boolean includeDefaultsOnly);
+
+    /**
+     * Batch version of finding which evaluations use a set of email templates (all of the same type),
+     * for display purposes - e.g. showing which evaluation a personal template belongs to in a list.
+     *
+     * @param emailTemplateIds the ids to check, all of the same emailTemplateType
+     * @param emailTemplateTypeConstant a constant, use the EMAIL_TEMPLATE constants from
+     * {@link org.sakaiproject.evaluation.constant.EvalConstants} to indicate the type
+     * @return a Map (emailTemplateId -&gt; evaluations using it); ids with no evaluations using them are absent
+     */
+    public Map<Long, List<EvalEvaluation>> getEvaluationsUsingEmailTemplates(Collection<Long> emailTemplateIds, String emailTemplateTypeConstant);
+
     // PERMISSIONS
 
     /**

--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/dao/EvaluationEmailTemplateDaoImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/dao/EvaluationEmailTemplateDaoImpl.java
@@ -14,7 +14,11 @@
  */
 package org.sakaiproject.evaluation.dao;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.query.Query;
@@ -45,7 +49,39 @@ public class EvaluationEmailTemplateDaoImpl extends EvaluationDaoHibernateSuppor
     }
 
     public List<EvalEmailTemplate> getEmailTemplates(String ownerUserId, String emailTemplateType, Boolean includeDefaultsOnly) {
-        StringBuilder hql = new StringBuilder("select emailTemplate from EvalEmailTemplate emailTemplate where 1 = 1");
+        Query<EvalEmailTemplate> query = currentSession().createQuery(
+                "select emailTemplate from EvalEmailTemplate emailTemplate "
+                + emailTemplatesWhereClause(ownerUserId, emailTemplateType, includeDefaultsOnly),
+                EvalEmailTemplate.class);
+        bindEmailTemplatesWhereParams(query, ownerUserId, emailTemplateType);
+        return query.list();
+    }
+
+    public List<EvalEmailTemplate> getEmailTemplates(String ownerUserId, String emailTemplateType, Boolean includeDefaultsOnly,
+            int firstResult, int maxResults) {
+        Query<EvalEmailTemplate> query = currentSession().createQuery(
+                "select emailTemplate from EvalEmailTemplate emailTemplate "
+                + emailTemplatesWhereClause(ownerUserId, emailTemplateType, includeDefaultsOnly)
+                + " order by emailTemplate.lastModified desc",
+                EvalEmailTemplate.class);
+        bindEmailTemplatesWhereParams(query, ownerUserId, emailTemplateType);
+        query.setFirstResult(firstResult);
+        query.setMaxResults(maxResults);
+        return query.list();
+    }
+
+    public int countEmailTemplates(String ownerUserId, String emailTemplateType, Boolean includeDefaultsOnly) {
+        Query<Long> query = currentSession().createQuery(
+                "select count(emailTemplate) from EvalEmailTemplate emailTemplate "
+                + emailTemplatesWhereClause(ownerUserId, emailTemplateType, includeDefaultsOnly),
+                Long.class);
+        bindEmailTemplatesWhereParams(query, ownerUserId, emailTemplateType);
+        Long count = query.uniqueResult();
+        return count == null ? 0 : count.intValue();
+    }
+
+    private String emailTemplatesWhereClause(String ownerUserId, String emailTemplateType, Boolean includeDefaultsOnly) {
+        StringBuilder hql = new StringBuilder("where 1 = 1");
         if (emailTemplateType != null) {
             hql.append(" and emailTemplate.type = :emailTemplateType");
         }
@@ -55,15 +91,16 @@ public class EvaluationEmailTemplateDaoImpl extends EvaluationDaoHibernateSuppor
         if (includeDefaultsOnly != null) {
             hql.append(includeDefaultsOnly ? " and emailTemplate.defaultType is not null" : " and emailTemplate.defaultType is null");
         }
+        return hql.toString();
+    }
 
-        Query<EvalEmailTemplate> query = currentSession().createQuery(hql.toString(), EvalEmailTemplate.class);
+    private void bindEmailTemplatesWhereParams(Query<?> query, String ownerUserId, String emailTemplateType) {
         if (emailTemplateType != null) {
             query.setParameter("emailTemplateType", emailTemplateType);
         }
         if (ownerUserId != null) {
             query.setParameter("ownerUserId", ownerUserId);
         }
-        return query.list();
     }
 
     public EvalEmailTemplate getDefaultEmailTemplate(String emailTemplateType) {
@@ -93,6 +130,45 @@ public class EvaluationEmailTemplateDaoImpl extends EvaluationDaoHibernateSuppor
                 EvalEvaluation.class)
                 .setParameter("emailTemplateId", emailTemplateId)
                 .list();
+    }
+
+    public Map<Long, List<EvalEvaluation>> getEvaluationsUsingEmailTemplates(Collection<Long> emailTemplateIds, String emailTemplateType) {
+        Map<Long, List<EvalEvaluation>> result = new HashMap<>();
+        if (emailTemplateIds == null || emailTemplateIds.isEmpty()) {
+            return result;
+        }
+        String property = getEvaluationEmailTemplateProperty(emailTemplateType);
+        // Single query for the whole batch of ids instead of one round trip per template
+        List<EvalEvaluation> evals = currentSession().createQuery(
+                "select evaluation from EvalEvaluation evaluation where evaluation." + property + ".id in (:emailTemplateIds)",
+                EvalEvaluation.class)
+                .setParameterList("emailTemplateIds", emailTemplateIds)
+                .list();
+        for (EvalEvaluation eval : evals) {
+            Long templateId = extractAssignedTemplateId(eval, property);
+            if (templateId != null) {
+                result.computeIfAbsent(templateId, k -> new ArrayList<>()).add(eval);
+            }
+        }
+        return result;
+    }
+
+    private Long extractAssignedTemplateId(EvalEvaluation eval, String property) {
+        EvalEmailTemplate template;
+        switch (property) {
+            case "availableEmailTemplate":
+                template = eval.getAvailableEmailTemplate();
+                break;
+            case "reminderEmailTemplate":
+                template = eval.getReminderEmailTemplate();
+                break;
+            case "submissionConfirmationEmailTemplate":
+                template = eval.getSubmissionConfirmationEmailTemplate();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported email template property: " + property);
+        }
+        return template != null ? template.getId() : null;
     }
 
     public int countEvaluationsUsingEmailTemplate(Long emailTemplateId, String emailTemplateType) {

--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationServiceImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationServiceImpl.java
@@ -23,6 +23,7 @@ import org.sakaiproject.evaluation.dao.EvaluationResponseDao;
 
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -776,6 +777,21 @@ public class EvalEvaluationServiceImpl implements EvalEvaluationService, Evaluat
     public List<EvalEmailTemplate> getEmailTemplatesForUser(String userId, String emailTemplateTypeConstant, Boolean includeDefaultsOnly) {
         String ownerUserId = commonLogic.isUserAdmin(userId) ? null : userId;
         return emailTemplateDao.getEmailTemplates(ownerUserId, emailTemplateTypeConstant, includeDefaultsOnly);
+    }
+
+    public List<EvalEmailTemplate> getEmailTemplatesForUser(String userId, String emailTemplateTypeConstant, Boolean includeDefaultsOnly,
+            int firstResult, int maxResults) {
+        String ownerUserId = commonLogic.isUserAdmin(userId) ? null : userId;
+        return emailTemplateDao.getEmailTemplates(ownerUserId, emailTemplateTypeConstant, includeDefaultsOnly, firstResult, maxResults);
+    }
+
+    public int countEmailTemplatesForUser(String userId, String emailTemplateTypeConstant, Boolean includeDefaultsOnly) {
+        String ownerUserId = commonLogic.isUserAdmin(userId) ? null : userId;
+        return emailTemplateDao.countEmailTemplates(ownerUserId, emailTemplateTypeConstant, includeDefaultsOnly);
+    }
+
+    public Map<Long, List<EvalEvaluation>> getEvaluationsUsingEmailTemplates(Collection<Long> emailTemplateIds, String emailTemplateTypeConstant) {
+        return emailTemplateDao.getEvaluationsUsingEmailTemplates(emailTemplateIds, emailTemplateTypeConstant);
     }
 
     public EvalEmailTemplate getDefaultEmailTemplate(String emailTemplateTypeConstant) {

--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/EvalEvaluationSetupServiceImpl.java
@@ -1750,6 +1750,14 @@ public class EvalEvaluationSetupServiceImpl implements EvalEvaluationSetupServic
                     // check eval/template permissions
                     securityChecks.checkEvalTemplateControl(userId, eval, emailTemplate);
                 }
+
+                // check submitted (confirmation) templates
+                l = emailTemplateDao.getEvaluationsUsingEmailTemplate(emailTemplate.getId(), EvalConstants.EMAIL_TEMPLATE_SUBMITTED);
+                for (int i = 0; i < l.size(); i++) {
+                    EvalEvaluation eval = (EvalEvaluation) l.get(i);
+                    // check eval/template permissions
+                    securityChecks.checkEvalTemplateControl(userId, eval, emailTemplate);
+                }
             } else {
                 // admin can modify any templates that they like
             }
@@ -1772,7 +1780,8 @@ public class EvalEvaluationSetupServiceImpl implements EvalEvaluationSetupServic
             String emailTemplateType = emailTemplate.getType();
 
             if (EvalConstants.EMAIL_TEMPLATE_AVAILABLE.equals(emailTemplateType)
-                    || EvalConstants.EMAIL_TEMPLATE_REMINDER.equals(emailTemplateType) ) {
+                    || EvalConstants.EMAIL_TEMPLATE_REMINDER.equals(emailTemplateType)
+                    || EvalConstants.EMAIL_TEMPLATE_SUBMITTED.equals(emailTemplateType) ) {
                 // get the evals that this template is used in
                 List<EvalEvaluation> evals = emailTemplateDao.getEvaluationsUsingEmailTemplate(emailTemplateId, emailTemplateType);
                 for (EvalEvaluation evaluation : evals) {
@@ -1781,6 +1790,8 @@ public class EvalEvaluationSetupServiceImpl implements EvalEvaluationSetupServic
                         evaluation.setAvailableEmailTemplate(null);
                     } else if ( EvalConstants.EMAIL_TEMPLATE_REMINDER.equals(emailTemplate.getType()) ) {
                         evaluation.setReminderEmailTemplate(null);
+                    } else if ( EvalConstants.EMAIL_TEMPLATE_SUBMITTED.equals(emailTemplate.getType()) ) {
+                        evaluation.setSubmissionConfirmationEmailTemplate(null);
                     }
                     queryDao.saveEvaluation(evaluation); // save the new template
                 }

--- a/sakai-evaluation-impl/src/test/org/sakaiproject/evaluation/dao/EvaluationDaoPortMethodsTest.java
+++ b/sakai-evaluation-impl/src/test/org/sakaiproject/evaluation/dao/EvaluationDaoPortMethodsTest.java
@@ -26,6 +26,7 @@ import org.sakaiproject.evaluation.dao.EvaluationSettingsDao;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -224,6 +225,14 @@ public class EvaluationDaoPortMethodsTest extends AbstractEvaluationDaoTest {
         Assert.assertNotNull(templates);
         Assert.assertEquals(2, templates.size());
 
+        // paginated variant: same filters, ordered by lastModified desc, page size smaller than total
+        Assert.assertEquals(2, emailTemplateDao.countEmailTemplates(null, templateType, false));
+        List<EvalEmailTemplate> firstPage = emailTemplateDao.getEmailTemplates(null, templateType, false, 0, 1);
+        Assert.assertEquals(1, firstPage.size());
+        List<EvalEmailTemplate> secondPage = emailTemplateDao.getEmailTemplates(null, templateType, false, 1, 1);
+        Assert.assertEquals(1, secondPage.size());
+        Assert.assertNotEquals(firstPage.get(0).getId(), secondPage.get(0).getId());
+
         EvalEmailTemplate foundDefault = emailTemplateDao.getDefaultEmailTemplate(defaultType);
         Assert.assertNotNull(foundDefault);
         Assert.assertEquals(defaultTemplate.getId(), foundDefault.getId());
@@ -255,6 +264,17 @@ public class EvaluationDaoPortMethodsTest extends AbstractEvaluationDaoTest {
         Assert.assertEquals(etdl.evaluationActive.getId(), evaluations.get(0).getId());
         Assert.assertEquals(1, emailTemplateDao.countEvaluationsUsingEmailTemplate(
                 etdl.emailTemplate6.getId(), EvalConstants.EMAIL_TEMPLATE_SUBMITTED));
+
+        // batch variant: resolves several templates of the same type in a single query
+        Map<Long, List<EvalEvaluation>> usingAvailable = emailTemplateDao.getEvaluationsUsingEmailTemplates(
+                Arrays.asList(etdl.emailTemplate1.getId(), ownerTemplate.getId()), EvalConstants.EMAIL_TEMPLATE_AVAILABLE);
+        Assert.assertEquals(1, usingAvailable.size()); // ownerTemplate is not assigned to any evaluation, so it is absent
+        Assert.assertEquals(1, usingAvailable.get(etdl.emailTemplate1.getId()).size());
+        Assert.assertEquals(etdl.evaluationNew.getId(), usingAvailable.get(etdl.emailTemplate1.getId()).get(0).getId());
+        Assert.assertFalse(usingAvailable.containsKey(ownerTemplate.getId()));
+
+        Assert.assertTrue(emailTemplateDao.getEvaluationsUsingEmailTemplates(
+                Collections.emptyList(), EvalConstants.EMAIL_TEMPLATE_AVAILABLE).isEmpty());
 
         Set<EvalEmailTemplate> templatesToDelete = new HashSet<>();
         templatesToDelete.add(ownerTemplate);

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages.properties
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages.properties
@@ -1078,6 +1078,24 @@ controlemailtemplates.no.templates=No email templates
 controlemailtemplates.template.saved.message=Saved the {0} email template
 controlemailtemplates.template.removed.message=Removed the email template ({0})
 controlemailtemplates.template.assigned.message=Assigned the {0} email template ({1}) to evaluation ({2})
+controlemailtemplates.header.template=Template
+controlemailtemplates.header.evaluation=Evaluation
+controlemailtemplates.no.evaluation=No evaluation is using this template
+controlemailtemplates.extra.evaluations=(+{0} more)
+controlemailtemplates.pager.label=Viewing {0}-{1} of total {2}
+controlemailtemplates.delete.confirm=Are you sure you want to delete this email template?
+controlemailtemplates.type.Created=Evaluation Created
+controlemailtemplates.type.Available=Evaluation Available
+controlemailtemplates.type.AvailableEvaluatee=Evaluation Available (Evaluatee)
+controlemailtemplates.type.OptIn=Instructor Opt-In Available
+controlemailtemplates.type.Reminder=Evaluation Reminder
+controlemailtemplates.type.Results=Evaluation Results Available
+controlemailtemplates.type.ConsolidatedAvailable=Evaluation Available (Consolidated)
+controlemailtemplates.type.ConsolidatedReminder=Evaluation Reminder (Consolidated)
+controlemailtemplates.type.ConsolidatedAvailSubject=Evaluation Available Subject (Consolidated)
+controlemailtemplates.type.ConsolidatedReminderSubject=Evaluation Reminder Subject (Consolidated)
+controlemailtemplates.type.Submitted=Submission Confirmation
+controlemailtemplates.type.JobCompleted=Job Completed
 
 controlemailtemplate.template.error.save.message=Something in the template ({0}) was incorrectly formatted so the template was not saved. Please re-check your template and try again.
 

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages_es_ES.properties
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages_es_ES.properties
@@ -713,6 +713,24 @@ controlemailtemplates.no.templates=No hay plantillas de correo electr\u00F3nico
 controlemailtemplates.template.saved.message=Guardada plantilla de correo electr\u00F3nico {0}
 controlemailtemplates.template.removed.message=Eliminada la plantilla de correo electr\u00F3nico ({0})
 controlemailtemplates.template.assigned.message=Plantilla {0} de correo electr\u00F3nico asignada ({1}) a la evaluaci\u00F3n ({2})
+controlemailtemplates.header.template=Plantilla
+controlemailtemplates.header.evaluation=Evaluaci\u00F3n
+controlemailtemplates.no.evaluation=Ninguna evaluaci\u00F3n est\u00E1 usando esta plantilla
+controlemailtemplates.extra.evaluations=(+{0} m\u00E1s)
+controlemailtemplates.pager.label=Mostrando {0}-{1} de un total de {2}
+controlemailtemplates.delete.confirm=\u00BFEst\u00E1 seguro de que desea eliminar esta plantilla de correo electr\u00F3nico?
+controlemailtemplates.type.Created=Evaluaci\u00F3n Creada
+controlemailtemplates.type.Available=Evaluaci\u00F3n Disponible
+controlemailtemplates.type.AvailableEvaluatee=Evaluaci\u00F3n Disponible (Evaluado)
+controlemailtemplates.type.OptIn=Adhesi\u00F3n del Instructor Disponible
+controlemailtemplates.type.Reminder=Recordatorio de Evaluaci\u00F3n
+controlemailtemplates.type.Results=Resultados de Evaluaci\u00F3n Disponibles
+controlemailtemplates.type.ConsolidatedAvailable=Evaluaci\u00F3n Disponible (Consolidado)
+controlemailtemplates.type.ConsolidatedReminder=Recordatorio de Evaluaci\u00F3n (Consolidado)
+controlemailtemplates.type.ConsolidatedAvailSubject=Asunto de Evaluaci\u00F3n Disponible (Consolidado)
+controlemailtemplates.type.ConsolidatedReminderSubject=Asunto de Recordatorio de Evaluaci\u00F3n (Consolidado)
+controlemailtemplates.type.Submitted=Confirmaci\u00F3n de Env\u00EDo
+controlemailtemplates.type.JobCompleted=Tarea Completada
 
 # Edit Email view
 modifyemail.page.title=Editar plantilla de correo electr\u00F3nico

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ControlEmailTemplatesController.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ControlEmailTemplatesController.java
@@ -139,14 +139,42 @@ public class ControlEmailTemplatesController extends EvalControllerSupport {
         if (totalCount > PAGE_SIZE) {
             int actualStart = totalCount == 0 ? 0 : startResult + 1;
             int actualEnd = Math.min(startResult + PAGE_SIZE, totalCount);
+            int totalPages = (totalCount + PAGE_SIZE - 1) / PAGE_SIZE;
             model.addAttribute("pagerMsg", new Object[]{ actualStart, actualEnd, totalCount });
             model.addAttribute("hasPrev", page > 0);
             model.addAttribute("hasNext", totalCount > startResult + PAGE_SIZE);
             model.addAttribute("prevPage", page - 1);
             model.addAttribute("nextPage", page + 1);
+            model.addAttribute("pageNumbers", buildPageNumbers(page, totalPages));
         }
 
         return "control_email_templates";
+    }
+
+    /**
+     * Builds the list of page numbers (0-based) to link to in the pager: always the first and
+     * last page, plus a window of pages around the current one; -1 marks a gap ("...") between
+     * non-consecutive numbers so the pager stays a fixed width even with hundreds of pages.
+     */
+    private List<Integer> buildPageNumbers(int currentPage, int totalPages) {
+        List<Integer> pages = new ArrayList<>();
+        int windowStart = Math.max(1, currentPage - 2);
+        int windowEnd = Math.min(totalPages - 2, currentPage + 2);
+
+        pages.add(0);
+        if (windowStart > 1) {
+            pages.add(-1);
+        }
+        for (int p = windowStart; p <= windowEnd; p++) {
+            pages.add(p);
+        }
+        if (windowEnd < totalPages - 2) {
+            pages.add(-1);
+        }
+        if (totalPages > 1) {
+            pages.add(totalPages - 1);
+        }
+        return pages;
     }
 
     /**

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ControlEmailTemplatesController.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/ControlEmailTemplatesController.java
@@ -15,9 +15,16 @@
 package org.sakaiproject.evaluation.tool.controllers;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Resource;
 
 import org.sakaiproject.evaluation.model.EvalEmailTemplate;
+import org.sakaiproject.evaluation.model.EvalEvaluation;
+import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,23 +43,36 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/control_email_templates")
 public class ControlEmailTemplatesController extends EvalControllerSupport {
 
-    private static final String DEFAULTS = "defaults";
-    private static final String OTHERS   = "others";
+    private static final String DEFAULTS  = "defaults";
+    private static final String OTHERS    = "others";
+    private static final int    PAGE_SIZE = 25;
+    private static final int    PREVIEW_MAX_CHARS = 200;
+
+    @Resource(name = "messageSource")
+    private MessageSource messageSource;
 
     @Data
     public static class EmailTemplateRow {
         Long    templateId;
         int     number;
         String  defaultType;
+        String  typeLabel;    // localized display label for the template's type
         String  subject;
-        String  messageHtml;  // line breaks already converted to &lt;br/>
+        String  messageHtml;      // preview, truncated, line breaks already converted to &lt;br/>
+        String  messageFullHtml;  // untruncated, for the "Preview" modal
         String  type;
         boolean canControl;
-        boolean canRemove;   // only if it is not a default template and the user can manage it
+        boolean canRemove;    // only if it is not a default template and the user can manage it
+        Long    evaluationId;      // first evaluation using this template, if any (personal templates only)
+        String  evaluationTitle;
+        int     extraEvaluationsCount; // more evaluations beyond the first one, if any (rare)
     }
 
     @GetMapping
-    public String show(@RequestParam(defaultValue = DEFAULTS) String switcher, Model model) {
+    public String show(@RequestParam(defaultValue = DEFAULTS) String switcher,
+                        @RequestParam(defaultValue = "0") int page,
+                        Locale locale,
+                        Model model) {
 
         String currentUserId = currentUserId();
         boolean userAdmin = commonLogic.isUserAdmin(currentUserId);
@@ -62,7 +82,25 @@ public class ControlEmailTemplatesController extends EvalControllerSupport {
             showDefaults = DEFAULTS.equals(switcher);
         }
 
-        List<EvalEmailTemplate> templatesList = evaluationService.getEmailTemplatesForUser(currentUserId, null, showDefaults);
+        int startResult = page * PAGE_SIZE;
+        List<EvalEmailTemplate> templatesList = evaluationService.getEmailTemplatesForUser(
+                currentUserId, null, showDefaults, startResult, PAGE_SIZE);
+        int totalCount = evaluationService.countEmailTemplatesForUser(currentUserId, null, showDefaults);
+
+        // Batch-resolve which evaluation uses each personal template, grouped by type so this is at
+        // most 3 extra queries per page (one per email type present), never one per row.
+        Map<String, List<Long>> idsByType = new HashMap<>();
+        for (EvalEmailTemplate et : templatesList) {
+            if (et.getDefaultType() == null) {
+                idsByType.computeIfAbsent(et.getType(), k -> new ArrayList<>()).add(et.getId());
+            }
+        }
+        Map<Long, List<EvalEvaluation>> evaluationsByTemplateId = new HashMap<>();
+        for (Map.Entry<String, List<Long>> entry : idsByType.entrySet()) {
+            evaluationsByTemplateId.putAll(
+                    evaluationService.getEvaluationsUsingEmailTemplates(entry.getValue(), entry.getKey()));
+        }
+
         List<EmailTemplateRow> rows = new ArrayList<>();
         for (int i = 0; i < templatesList.size(); i++) {
             EvalEmailTemplate et = templatesList.get(i);
@@ -70,15 +108,24 @@ public class ControlEmailTemplatesController extends EvalControllerSupport {
             if (!userAdmin && et.getDefaultType() != null) continue;
             EmailTemplateRow row = new EmailTemplateRow();
             row.setTemplateId(et.getId());
-            row.setNumber(i + 1);
+            row.setNumber(startResult + i + 1);
             row.setDefaultType(et.getDefaultType());
+            row.setTypeLabel(resolveTypeLabel(et.getType(), locale));
             row.setSubject(et.getSubject());
-            String msg = et.getMessage() != null ? et.getMessage() : "";
-            row.setMessageHtml(msg.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\r\n", "<br/>").replace("\n", "<br/>"));
+            row.setMessageHtml(previewHtml(et.getMessage()));
+            row.setMessageFullHtml(escapeHtml(et.getMessage()));
             row.setType(et.getType());
             boolean canControl = evaluationService.canControlEmailTemplate(currentUserId, null, et.getId());
             row.setCanControl(canControl);
             row.setCanRemove(canControl && et.getDefaultType() == null);
+
+            List<EvalEvaluation> evals = evaluationsByTemplateId.get(et.getId());
+            if (evals != null && !evals.isEmpty()) {
+                row.setEvaluationId(evals.get(0).getId());
+                row.setEvaluationTitle(evals.get(0).getTitle());
+                row.setExtraEvaluationsCount(evals.size() - 1);
+            }
+
             rows.add(row);
         }
 
@@ -87,6 +134,48 @@ public class ControlEmailTemplatesController extends EvalControllerSupport {
         model.addAttribute("switcher", switcher);
         model.addAttribute("DEFAULTS", DEFAULTS);
         model.addAttribute("OTHERS", OTHERS);
+
+        model.addAttribute("page", page);
+        if (totalCount > PAGE_SIZE) {
+            int actualStart = totalCount == 0 ? 0 : startResult + 1;
+            int actualEnd = Math.min(startResult + PAGE_SIZE, totalCount);
+            model.addAttribute("pagerMsg", new Object[]{ actualStart, actualEnd, totalCount });
+            model.addAttribute("hasPrev", page > 0);
+            model.addAttribute("hasNext", totalCount > startResult + PAGE_SIZE);
+            model.addAttribute("prevPage", page - 1);
+            model.addAttribute("nextPage", page + 1);
+        }
+
         return "control_email_templates";
+    }
+
+    /**
+     * Localizes an EvalConstants.EMAIL_TEMPLATE_* type value (e.g. "Available") into a
+     * human-readable label. The message key is built from the type value itself (spaces
+     * stripped, e.g. "Available Evaluatee" -> "controlemailtemplates.type.AvailableEvaluatee")
+     * since type and defaultType share the same raw values for every seeded default template.
+     */
+    private String resolveTypeLabel(String type, Locale locale) {
+        String key = "controlemailtemplates.type." + (type != null ? type.replace(" ", "") : "");
+        return messageSource.getMessage(key, null, type, locale);
+    }
+
+    /**
+     * HTML-escapes and truncates the message body for the list preview - the full text is only
+     * shown in the "Preview" modal; showing the whole email inline made the table unreadable.
+     */
+    private String previewHtml(String message) {
+        String msg = message != null ? message : "";
+        boolean truncated = msg.length() > PREVIEW_MAX_CHARS;
+        if (truncated) {
+            msg = msg.substring(0, PREVIEW_MAX_CHARS);
+        }
+        return truncated ? escapeHtml(msg) + "&hellip;" : escapeHtml(msg);
+    }
+
+    private String escapeHtml(String message) {
+        String msg = message != null ? message : "";
+        return msg.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                .replace("\r\n", "<br/>").replace("\n", "<br/>");
     }
 }

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/templates/control_email_templates.html
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/templates/control_email_templates.html
@@ -133,6 +133,13 @@
             <a th:if="${hasPrev}"
                th:href="@{/control_email_templates(switcher=${switcher}, page=${prevPage})}">&lt;</a>
             <span th:unless="${hasPrev}">&lt;</span>
+            <th:block th:each="pn : ${pageNumbers}">
+                <span th:if="${pn == -1}" class="listPagerGap">&hellip;</span>
+                <span th:if="${pn != -1 and pn == page}" class="listPagerCurrent" th:text="${pn + 1}">1</span>
+                <a th:if="${pn != -1 and pn != page}"
+                   th:href="@{/control_email_templates(switcher=${switcher}, page=${pn})}"
+                   th:text="${pn + 1}">1</a>
+            </th:block>
             <a th:if="${hasNext}"
                th:href="@{/control_email_templates(switcher=${switcher}, page=${nextPage})}">&gt;</a>
             <span th:unless="${hasNext}">&gt;</span>

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/templates/control_email_templates.html
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/templates/control_email_templates.html
@@ -25,6 +25,10 @@
     <script src="/library/js/headscripts.js" type="text/javascript"></script>
     <link th:href="${skinRepo + '/' + skinDefault + '/tool.css'}" type="text/css" rel="stylesheet" media="screen"/>
     <link th:href="@{/content/css/evaluation_base.css}" type="text/css" rel="stylesheet" media="all"/>
+    <script src="/library/webjars/jquery/1.12.4/jquery.min.js"></script>
+    <script src="/library/webjars/jquery-ui/1.12.1/jquery-ui.min.js"></script>
+    <script src="/library/webjars/bootstrap/5.2.0/js/bootstrap.bundle.min.js"></script>
+    <th:block th:replace="~{fragments/evalsys_scripts :: evalsys}"></th:block>
 </head>
 <body>
 <div class="portletBody evaluation">
@@ -58,50 +62,101 @@
 
     <!-- Email templates list -->
     <div th:if="${not #lists.isEmpty(emailTemplateRows)}">
-        <table class="evalsysTable">
+        <table class="evalsysTable emailTemplatesTable">
             <thead>
                 <tr>
                     <th>#</th>
-                    <th><!-- Type/Title --></th>
+                    <th th:text="#{controlemailtemplates.header.template}">Template</th>
+                    <th th:text="#{controlemailtemplates.header.evaluation}">Evaluation</th>
                     <th class="screenOnly"><!-- Actions --></th>
                 </tr>
             </thead>
             <tbody>
-                <tr th:each="row : ${emailTemplateRows}">
-                    <td th:text="${row.number}" nowrap="nowrap">1</td>
-                    <td>
-                        <div th:text="${row.defaultType}">Template Type</div>
-                        <div th:text="#{controlemailtemplates.subject(${row.subject})}">Subject: ...</div>
-                        <div th:utext="${row.messageHtml}">Message body</div>
-                    </td>
-                    <td class="itemAction screenOnly">
-                        <!-- Edit -->
-                        <a th:if="${row.canControl}"
-                           th:href="@{/modify_email(templateId=${row.templateId},emailType=${row.type})}"
-                           th:text="#{general.command.edit}">Edit</a>
-                        <span th:unless="${row.canControl}"
-                              th:text="#{general.command.edit}"
-                              class="inactive">Edit</span>
-                        <!-- Delete (non-default templates only) -->
-                        <form th:if="${row.canRemove}"
-                              th:action="@{/remove_email(emailTemplateId=${row.templateId})}"
-                              method="post"
-                              class="inlineForm left-separator">
-                            <input type="submit" th:value="#{general.command.delete}" class="makeLink"/>
-                        </form>
-                        <span th:unless="${row.canRemove}"
-                              th:text="#{general.command.delete}"
-                              class="inactive left-separator">Delete</span>
-                    </td>
-                </tr>
+                <th:block th:each="row : ${emailTemplateRows}">
+                    <tr class="emailTemplateTypeRow">
+                        <th th:text="${row.number}" nowrap="nowrap">1</th>
+                        <th colspan="3" th:text="${row.typeLabel}">Template Type</th>
+                    </tr>
+                    <tr>
+                        <td></td>
+                        <td>
+                            <div th:text="#{controlemailtemplates.subject(${row.subject})}">Subject: ...</div>
+                            <div th:utext="${row.messageHtml}">Message body</div>
+                            <a href="#" class="preview_email_template"
+                               th:data-target="${'emailFull-' + row.templateId}"
+                               th:data-subject="${row.subject}"
+                               th:text="#{general.command.preview}">Preview</a>
+                            <div th:id="${'emailFull-' + row.templateId}" th:utext="${row.messageFullHtml}"
+                                 style="display:none">Full message body</div>
+                        </td>
+                        <td>
+                            <a th:if="${row.evaluationId != null}"
+                               th:href="@{/evaluation_settings(evaluationId=${row.evaluationId})}"
+                               th:text="${row.evaluationTitle}">Evaluation title</a>
+                            <span th:if="${row.evaluationId != null and row.extraEvaluationsCount > 0}"
+                                  th:text="#{controlemailtemplates.extra.evaluations(${row.extraEvaluationsCount})}"> (+1 more)</span>
+                            <span th:if="${row.evaluationId == null and row.defaultType == null}"
+                                  class="inactive"
+                                  th:text="#{controlemailtemplates.no.evaluation}">No evaluation is using this template</span>
+                        </td>
+                        <td class="itemAction screenOnly">
+                            <!-- Edit -->
+                            <a th:if="${row.canControl}"
+                               th:href="@{/modify_email(templateId=${row.templateId},emailType=${row.type})}"
+                               th:text="#{general.command.edit}">Edit</a>
+                            <span th:unless="${row.canControl}"
+                                  th:text="#{general.command.edit}"
+                                  class="inactive">Edit</span>
+                            <!-- Delete (non-default templates only) -->
+                            <form th:if="${row.canRemove}"
+                                  th:action="@{/remove_email(emailTemplateId=${row.templateId})}"
+                                  method="post"
+                                  class="inlineForm left-separator"
+                                  onsubmit="return confirm(this.dataset.confirm)"
+                                  th:data-confirm="#{controlemailtemplates.delete.confirm}">
+                                <input type="submit" th:value="#{general.command.delete}" class="makeLink"/>
+                            </form>
+                            <span th:unless="${row.canRemove}"
+                                  th:text="#{general.command.delete}"
+                                  class="inactive left-separator">Delete</span>
+                        </td>
+                    </tr>
+                </th:block>
             </tbody>
         </table>
+
+        <!-- Pager -->
+        <div th:if="${pagerMsg != null}" class="listNav listPager">
+            <span class="listPagerCount" th:text="#{controlemailtemplates.pager.label(${pagerMsg[0]}, ${pagerMsg[1]}, ${pagerMsg[2]})}">
+                Viewing 1-25 of total 100
+            </span>
+            <a th:if="${hasPrev}"
+               th:href="@{/control_email_templates(switcher=${switcher}, page=${prevPage})}">&lt;</a>
+            <span th:unless="${hasPrev}">&lt;</span>
+            <a th:if="${hasNext}"
+               th:href="@{/control_email_templates(switcher=${switcher}, page=${nextPage})}">&gt;</a>
+            <span th:unless="${hasNext}">&gt;</span>
+        </div>
     </div>
 
     <p th:if="${#lists.isEmpty(emailTemplateRows)}" class="instructionText highlightPanel"
        th:text="#{controlemailtemplates.no.templates}">No email templates</p>
 
+    <!-- Bootstrap Modal for the full email preview -->
+    <div class="modal fade" id="emailTemplatePreviewModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header" style="cursor:move">
+                    <span id="emailTemplatePreviewModalTitle" class="modal-title"></span>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body" id="emailTemplatePreviewModalBody" style="overflow:visible"></div>
+            </div>
+        </div>
+    </div>
+
 </div>
+<script type="text/javascript">evalsys.initControlEmailTemplates();</script>
 <th:block th:if="${mainFrameId != ''}"><script th:inline="javascript">setMainFrameHeight([[${mainFrameId}]]);</script></th:block>
 </body>
 </html>

--- a/sakai-evaluation-tool/src/webapp/content/css/scss/_layout.scss
+++ b/sakai-evaluation-tool/src/webapp/content/css/scss/_layout.scss
@@ -544,6 +544,34 @@
     }
   }
 
+  /* .evalsysTable has no styling of its own anywhere in this stylesheet - fine for single-line
+     rows (My Items, My Templates) but with multi-line content (My Email Templates previews) rows
+     blend into each other with nothing marking where one ends and the next begins.
+     Selector combines both classes (rather than just .emailTemplatesTable) so its specificity
+     beats the .evalsysTable rules in _sakai25-compat.scss, which would otherwise win the
+     nth-child(even)/td tie and silently swallow the rules below. */
+  .emailTemplatesTable.evalsysTable {
+    border-collapse: collapse;
+    width: 100%;
+
+    td, th {
+      vertical-align: top;
+      padding: 0.5em;
+    }
+
+    /* Each template spans two rows: a sub-header row with its type, then its content row.
+       The sub-header carries the visual separation between templates, so no zebra striping
+       is needed on top of it. */
+    tbody tr.emailTemplateTypeRow {
+      border-top: 2px solid var(--bs-border-color, #ccc);
+
+      th {
+        background-color: var(--bs-tertiary-bg, #e9ecef);
+        text-align: left;
+      }
+    }
+  }
+
 } //end namespace
 
 /////////////////////////

--- a/sakai-evaluation-tool/src/webapp/content/css/scss/evaluation/_utilities.scss
+++ b/sakai-evaluation-tool/src/webapp/content/css/scss/evaluation/_utilities.scss
@@ -328,6 +328,17 @@ a.less { background: none; padding-right: 0; padding-left: 0; }
   font-size: .8em;
 }
 
+.listPager span.listPagerGap {
+  border: 0;
+  background: transparent;
+  padding: 0 0.3em;
+}
+
+.listPager span.listPagerCurrent {
+  border: 1px solid var(--bs-primary-border-subtle, rgba(13, 110, 253, 0.4));
+  background: var(--bs-primary-bg-subtle, rgba(13, 110, 253, 0.15)) !important;
+}
+
 /* for fullDisplayHorizontal (adjustable) support - default sizes, styles of blocks that 
 	have heigth adjusted via jquery. Waiting on a opinions from Hattie see:
 	http://bugs.sakaiproject.org/jira/browse/EVALSYS-426*/

--- a/sakai-evaluation-tool/src/webapp/content/js/evalsys-pages.js
+++ b/sakai-evaluation-tool/src/webapp/content/js/evalsys-pages.js
@@ -83,6 +83,31 @@ evalsys.initControlScales = function() {
     modalEl.addEventListener('hidden.bs.modal', function() { $body.html(''); });
 };
 
+evalsys.initControlEmailTemplates = function() {
+    var modalEl = document.getElementById('emailTemplatePreviewModal');
+    var modal = new bootstrap.Modal(modalEl);
+    var $title = jQuery('#emailTemplatePreviewModalTitle');
+    var $body = jQuery('#emailTemplatePreviewModalBody');
+
+    modalEl.addEventListener('show.bs.modal', function() {
+        evalsys.positionModalInViewport(modalEl);
+    });
+
+    jQuery(document).on('click', 'a.preview_email_template', function(e) {
+        e.preventDefault();
+        var $source = jQuery(document.getElementById(this.dataset.target));
+        $title.text(this.dataset.subject);
+        $body.html($source.html());
+        modal.show();
+    });
+
+    modalEl.addEventListener('shown.bs.modal', function() {
+        jQuery(modalEl).find('.modal-dialog').draggable({ handle: '.modal-header' });
+    });
+
+    modalEl.addEventListener('hidden.bs.modal', function() { $body.html(''); });
+};
+
 evalsys.initModifyScales = function() {
     var $textboxes = $("div.labelindnt input:text");
     $textboxes.attr("maxlength", "250"); // force the existing ones first


### PR DESCRIPTION
## Summary
- "My Email Templates" now shows which evaluation (if any) uses each personal template, resolved in batches to avoid N+1 queries.
- Added pagination (25/page) sorted by most recently modified, redesigned the table so each template has a labelled sub-header row, added a delete confirmation, and added a "Preview" modal for the full (untruncated) email content.
- Fixed two related gaps in `EvalEvaluationSetupServiceImpl`, both dating back to commit 10d1688f (2016, EVALSYS-1403) which added `EMAIL_TEMPLATE_SUBMITTED` support to `assignEmailTemplate()` but never propagated it everywhere: `removeEmailTemplate()` left evaluations pointing at a deleted SUBMITTED template instead of unlinking it, and `saveEmailTemplate()` skipped the permission check entirely for non-admins editing an existing SUBMITTED template.

See EVALSYS-1616 for full details.

## Test plan
- [x] `EvaluationDaoPortMethodsTest.testEmailTemplateLookups()` extended with pagination and batch-lookup assertions
- [ ] Manual verification pending deployment (tracked in EVALSYS-1616)

🤖 Generated with [Claude Code](https://claude.com/claude-code)