### PR TITLE
EVALSYS-1617 Resolve the display locale from the user's Sakai preference

### DIFF
--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/SakaiLocaleResolver.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/controllers/SakaiLocaleResolver.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2005 Sakai Foundation Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.sakaiproject.evaluation.tool.controllers;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.sakaiproject.util.ResourceLoader;
+import org.springframework.web.servlet.LocaleResolver;
+
+/**
+ * Resolves the request Locale from the current user's saved Sakai language
+ * preference instead of Spring's default (the browser's Accept-Language
+ * header), which ignores it. Must be registered under the bean id
+ * "localeResolver" - DispatcherServlet looks it up by that exact name.
+ */
+public class SakaiLocaleResolver implements LocaleResolver {
+
+    @Override
+    public Locale resolveLocale(HttpServletRequest request) {
+        return new ResourceLoader().getLocale();
+    }
+
+    @Override
+    public void setLocale(HttpServletRequest request, HttpServletResponse response, Locale locale) {
+        new ResourceLoader().setContextLocale(locale);
+    }
+}

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/evaluation-mvc-servlet.xml
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/evaluation-mvc-servlet.xml
@@ -29,6 +29,11 @@
 
     <mvc:annotation-driven/>
 
+    <!-- Resolves the display locale from the user's saved Sakai preference instead of the
+         browser's Accept-Language header. Bean id must be exactly "localeResolver" -
+         DispatcherServlet looks it up by that name. -->
+    <bean id="localeResolver" class="org.sakaiproject.evaluation.tool.controllers.SakaiLocaleResolver"/>
+
     <!-- Interceptor that adds skinRepo and skinDefault to the model of every view -->
     <mvc:interceptors>
         <bean class="org.sakaiproject.evaluation.tool.controllers.SakaiSkinInterceptor"/>


### PR DESCRIPTION
## Summary
- Evalsys did not follow the language a user selected in Sakai Preferences, rendering instead in whatever locale the browser's Accept-Language header implied. Root cause: no `LocaleResolver` bean was registered for the Spring MVC dispatcher, so it fell back to the default Accept-Header-based resolution, and `ResourceLoaderMessageSource` only consults `PreferencesService` when the passed-in locale is `null` - which it never was.
- This is a regression from the RSF removal / Spring MVC + Thymeleaf migration (EVALSYS-1610, PR #179): RSF's `SakaiLocaleDeterminer` used to do exactly `new ResourceLoader().getLocale()` for every request; the migration never registered an equivalent.
- Added `SakaiLocaleResolver` (implements Spring's `LocaleResolver` via that same call) and registered it as bean `localeResolver` in `evaluation-mvc-servlet.xml`. Fixes every `#{...}` message and every `Locale`-typed controller argument at once - no controller or template changes needed.

See EVALSYS-1617 for full details.

## Test plan
- [x] Manually verified: set a different language in My Workspace > Preferences than the browser's own language, confirmed evalsys pages render in the Sakai preference, not the browser's language.
- [x] Confirmed pages that already matched the browser language still render correctly (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)